### PR TITLE
Add TimerHook as a hook for recording time spent in events

### DIFF
--- a/seagrass/hooks/__init__.py
+++ b/seagrass/hooks/__init__.py
@@ -4,6 +4,7 @@ from .file_open_hook import FileOpenHook
 from .logging_hook import LoggingHook
 from .stack_trace_hook import StackTraceHook
 from .profiler_hook import ProfilerHook
+from .timer_hook import TimerHook
 
 __all__ = [
     "CounterHook",
@@ -11,4 +12,5 @@ __all__ = [
     "LoggingHook",
     "ProfilerHook",
     "StackTraceHook",
+    "TimerHook",
 ]

--- a/seagrass/hooks/timer_hook.py
+++ b/seagrass/hooks/timer_hook.py
@@ -1,0 +1,40 @@
+# A hook that measures the amount of time spent in various events.
+
+import logging
+import time
+import typing as t
+from collections import defaultdict
+
+
+class TimerHook:
+
+    # Relatively high prehook/posthook priority so that TimerHook gets
+    # called soon before and after a wrapped function.
+    prehook_priority: int = 8
+    posthook_priority: int = 8
+
+    event_times: t.DefaultDict[str, float]
+
+    def __init__(self):
+        self.event_times = defaultdict(float)
+
+    def prehook(
+        self, event_name: str, args: t.Tuple[t.Any, ...], kwargs: t.Dict[str, t.Any]
+    ) -> float:
+        # Return the current time so that it can be used by posthook()
+        return time.time()
+
+    def posthook(self, event_name: str, result: t.Any, context: float) -> None:
+        # The context stores the time when the prehook was called. We can calculate the
+        # total time spent in the event as roughly (not accounting for other hooks) equal
+        # to the current time minus the time returned by prehook().
+        current_time = time.time()
+        self.event_times[event_name] += current_time - context
+
+    def reset(self) -> None:
+        self.event_times.clear()
+
+    def log_results(self, logger: logging.Logger) -> None:
+        logger.info("%s results:", self.__class__.__name__)
+        for (event, time_in_event) in self.event_times.items():
+            logger.info("    Time spent in %s: %f", event, time_in_event)

--- a/test/hooks/test_timer_hook.py
+++ b/test/hooks/test_timer_hook.py
@@ -1,0 +1,35 @@
+# Tests for the TimerHook auditing hook
+
+import time
+import unittest
+from test.base import HookTestCaseBase
+from seagrass.hooks import TimerHook
+
+
+class TimerHookTestCase(HookTestCaseBase):
+
+    hook_class = TimerHook
+
+    def test_hook_function(self):
+        ausleep = self.auditor.wrap(time.sleep, "test.time.sleep", hooks=[self.hook])
+
+        ausleep(0.01)
+        with self.auditor.audit():
+            ausleep(0.01)
+        ausleep(0.01)
+
+        recorded_time = self.hook.event_times["test.time.sleep"]
+        self.assertAlmostEqual(recorded_time, 0.01, delta=0.005)
+
+        # Check logging output
+        self.auditor.log_results()
+        self.logging_output.seek(0)
+        output = [line.rstrip() for line in self.logging_output.readlines()]
+        self.assertEqual(output[0], "(INFO) TimerHook results:")
+        self.assertEqual(
+            output[1], "(INFO)     Time spent in test.time.sleep: %f" % recorded_time
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Add a new Seagrass hook, `TimerHook`, that records the amount of time that's spent in hooked events.