### PR TITLE
Improvements to FileOpenHook

### DIFF
--- a/seagrass/hooks/file_open_hook.py
+++ b/seagrass/hooks/file_open_hook.py
@@ -23,7 +23,6 @@ class FileOpenHook:
 
     file_open_counter: t.DefaultDict[str, t.Counter[FileOpenInfo]]
     track_nested_opens: bool
-    __enabled: bool = False
     __current_event_stack: t.List[str]
 
     def __init__(self, track_nested_opens: bool = False):
@@ -36,11 +35,7 @@ class FileOpenHook:
 
     def __sys_audit_hook(self, event, args):
         try:
-            if self.__enabled and event == "open":
-                assert (
-                    len(self.__current_event_stack) > 0
-                ), f"{self.__class__.__name__}'s current event stack is empty!"
-
+            if len(self.__current_event_stack) > 0 and event == "open":
                 filename, mode, flags = args
                 info = FileOpenInfo(filename, mode, flags)
 
@@ -65,8 +60,6 @@ class FileOpenHook:
     def prehook(
         self, event_name: str, args: t.Tuple[t.Any, ...], kwargs: t.Dict[str, t.Any]
     ) -> None:
-        # Set __enabled so that we can enter the body of __sys_audit_hook
-        self.__enabled = True
         self.__current_event_stack.append(event_name)
 
     def posthook(
@@ -75,7 +68,6 @@ class FileOpenHook:
         result: t.Any,
         context: None,
     ) -> None:
-        self.__enabled = False
         self.__current_event_stack.pop()
 
     def reset(self) -> None:

--- a/test/hooks/test_file_open_hook.py
+++ b/test/hooks/test_file_open_hook.py
@@ -8,7 +8,11 @@ from seagrass.hooks import FileOpenHook
 
 class FileOpenHookTestCase(HookTestCaseBase):
 
-    hook_class = FileOpenHook
+    # We set track_nested_opens = True so that if we call open() in an event that's
+    # nested in another event, we will count the open() for both events.
+    @staticmethod
+    def hook_gen():
+        return FileOpenHook(track_nested_opens=True)
 
     def test_hook_function(self):
         @self.auditor.decorate("test.say_hello", hooks=[self.hook])
@@ -44,6 +48,43 @@ class FileOpenHookTestCase(HookTestCaseBase):
             # Header line + one line for one event + two lines for one read of the temporary
             # file, one write to it
             self.assertEqual(len(lines), 4)
+
+    def test_nested_calls_to_hooked_functions(self):
+        @self.auditor.decorate("test.readlines", hooks=[self.hook])
+        def readlines(filename):
+            with open(filename, "r") as f:
+                return f.readlines()
+
+        @self.auditor.decorate("test.tabify", hooks=[self.hook])
+        def tabify(filename):
+            return ["\t" + line for line in readlines(filename)]
+
+        with tempfile.NamedTemporaryFile() as f:
+            with self.auditor.audit():
+                with open(f.name, "w") as f:
+                    f.write("hello\nworld!")
+                tabify(f.name)
+
+            self.assertEqual(
+                sorted(self.hook.file_open_counter.keys()),
+                ["test.readlines", "test.tabify"],
+            )
+
+            readlines_keys = list(self.hook.file_open_counter["test.readlines"].keys())
+            tabify_keys = list(self.hook.file_open_counter["test.tabify"].keys())
+
+            # Only opened one file in our events, and only for reading
+            self.assertEqual(len(readlines_keys), 1)
+            self.assertEqual(len(tabify_keys), 1)
+            self.assertEqual(readlines_keys[0], tabify_keys[0])
+
+            open_info = readlines_keys[0]
+            self.assertEqual(open_info.filename, f.name)
+            self.assertEqual(open_info.mode, "r")
+            self.assertEqual(
+                self.hook.file_open_counter["test.readlines"][open_info], 1
+            )
+            self.assertEqual(self.hook.file_open_counter["test.tabify"][open_info], 1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
- Store info about opened files in a new `FileOpenInfo` named tuple, rather than constructing a key string from the file information.
- Fix bugs in `FileOpenHook` when two or more events both calling the hook were nested.
- Add a `track_nested_opens` keyword argument to`FileOpenHook.__init__` that determines whether or not we count an open that is nested inside another event for the outer event.