### PR TITLE
Make it possible to create and raise "empty events" (#6).

### DIFF
--- a/docs/source/api/index.rst
+++ b/docs/source/api/index.rst
@@ -7,5 +7,6 @@ API documentation
 
    seagrass
    seagrass.base
+   seagrass.errors
    seagrass.events
    seagrass.hooks

--- a/docs/source/api/seagrass.errors.rst
+++ b/docs/source/api/seagrass.errors.rst
@@ -1,0 +1,9 @@
+.. _mod-docs-seagrass-errors:
+
+===================
+``seagrass.errors``
+===================
+
+.. automodule:: seagrass.errors
+   :members:
+   :show-inheritance:

--- a/seagrass/__init__.py
+++ b/seagrass/__init__.py
@@ -3,4 +3,5 @@ from .auditor import Auditor, get_audit_logger
 
 __all__ = [
     "Auditor",
+    "get_audit_logger",
 ]

--- a/seagrass/errors.py
+++ b/seagrass/errors.py
@@ -1,0 +1,21 @@
+# Basic errors that can be thrown while using Seagrass
+
+
+class SeagrassError(Exception):
+    """A generic error for the Seagrass library."""
+
+
+class EventNotFoundError(SeagrassError):
+    """Raised when we try to reference an auditing event that does not currently
+    exist."""
+
+    event_name: str
+
+    def __init__(self, event_name: str):
+        """Create a new EventNotFoundError.
+
+        :param str event_name: the name of the event that could not be found.
+        """
+        self.event_name = event_name
+        msg = f"Audit event not found: {event_name}"
+        super(Exception, self).__init__(msg)


### PR DESCRIPTION
- Create seagrass/errors.py for custom errors for the Seagrass library.
  Define two new error types, SeagrassError and EventNotFoundError.
- Define two new functions for seagrass.Auditor, create_event and
  raise_event. create_event makes a new empty event, i.e. an event that
  calls its prehooks and posthooks but doesn't do anything else.
  Meanwhile, raise_event looks for an event with the input name and
  evaluates it on the input arguments if it's found. If it isn't found,
  we raise an EventNotFoundError.
- Add documentation for seagrass.base.get_audit_logger.

Closes #6.