### PR TITLE
Fix the logger keyword argument for Auditor.

### DIFF
--- a/seagrass/auditor.py
+++ b/seagrass/auditor.py
@@ -37,7 +37,7 @@ class Auditor:
         if isinstance(logger, logging.Logger):
             self.logger = logger
         else:
-            self.logger = logging.getLogger("seagrass")
+            self.logger = logging.getLogger(logger)
 
         self.events = dict()
         self.event_wrappers = dict()


### PR DESCRIPTION
Previously, there was a bug where Auditor would not properly respect the
"logger" keyword argument to `Auditor.__init__` if the logger was
specified as a string. Instead, Auditor would simply revert to using the
default "seagrass" auditor.

This commit fixes this bug and adds more tests to check that Auditor
respects the logger keyword argument.