### PR TITLE
Sort log_results output by event name.

### DIFF
--- a/seagrass/hooks/counter_hook.py
+++ b/seagrass/hooks/counter_hook.py
@@ -24,5 +24,5 @@ class CounterHook:
 
     def log_results(self, logger: logging.Logger) -> None:
         logger.info("Calls to events recorded by %s:", self.__class__.__name__)
-        for (event, count) in self.event_counter.items():
-            logger.info("    %s: %d", event, count)
+        for event in sorted(self.event_counter):
+            logger.info("    %s: %d", event, self.event_counter[event])

--- a/seagrass/hooks/file_open_hook.py
+++ b/seagrass/hooks/file_open_hook.py
@@ -75,9 +75,9 @@ class FileOpenHook:
 
     def log_results(self, logger: logging.Logger) -> None:
         logger.info("%s results (file opened, count):", self.__class__.__name__)
-        for (event, counter) in self.file_open_counter.items():
+        for event in sorted(self.file_open_counter):
             logger.info("  event %s:", event)
-            for (info, count) in counter.items():
+            for (info, count) in self.file_open_counter[event].items():
                 logger.info(
                     "    %s (mode=%s, flags=%s): opened %d times",
                     info.filename,

--- a/seagrass/hooks/timer_hook.py
+++ b/seagrass/hooks/timer_hook.py
@@ -36,5 +36,5 @@ class TimerHook:
 
     def log_results(self, logger: logging.Logger) -> None:
         logger.info("%s results:", self.__class__.__name__)
-        for (event, time_in_event) in self.event_times.items():
-            logger.info("    Time spent in %s: %f", event, time_in_event)
+        for event in sorted(self.event_times):
+            logger.info("    Time spent in %s: %f", event, self.event_times[event])

--- a/test/hooks/test_counter_hook.py
+++ b/test/hooks/test_counter_hook.py
@@ -7,7 +7,7 @@ import unittest
 
 class CounterHookTestCase(HookTestCaseBase):
 
-    hook_class = CounterHook
+    hook_gen = CounterHook
 
     def test_hook_function(self):
         @self.auditor.decorate("test.say_hello", hooks=[self.hook])

--- a/test/hooks/test_counter_hook.py
+++ b/test/hooks/test_counter_hook.py
@@ -1,34 +1,58 @@
 # Tests for the CounterHook auditing hook.
 
-from seagrass import Auditor
 from seagrass.hooks import CounterHook
+from test.base import HookTestCaseBase
 import unittest
 
 
-class CounterHookTestCase(unittest.TestCase):
-    def test_hook_function(self):
-        auditor = Auditor()
-        hook = CounterHook()
+class CounterHookTestCase(HookTestCaseBase):
 
-        @auditor.decorate("test.say_hello", hooks=[hook])
+    hook_class = CounterHook
+
+    def test_hook_function(self):
+        @self.auditor.decorate("test.say_hello", hooks=[self.hook])
         def say_hello(name: str) -> str:
             return f"Hello, {name}!"
 
-        self.assertEqual(hook.event_counter["test.say_hello"], 0)
+        self.assertEqual(self.hook.event_counter["test.say_hello"], 0)
 
         # Hook should not get called outside of an auditing context
         say_hello("Alice")
-        self.assertEqual(hook.event_counter["test.say_hello"], 0)
+        self.assertEqual(self.hook.event_counter["test.say_hello"], 0)
 
-        with auditor.audit():
+        with self.auditor.audit():
             for name in ("Alice", "Bob", "Cathy"):
                 say_hello(name)
-        self.assertEqual(hook.event_counter["test.say_hello"], 3)
-        self.assertEqual(set(hook.event_counter), set(("test.say_hello",)))
+        self.assertEqual(self.hook.event_counter["test.say_hello"], 3)
+        self.assertEqual(set(self.hook.event_counter), set(("test.say_hello",)))
 
         # Upon resetting the hook, all event counts should be set back to zero
-        hook.reset()
-        self.assertEqual(hook.event_counter["test.say_hello"], 0)
+        self.hook.reset()
+        self.assertEqual(self.hook.event_counter["test.say_hello"], 0)
+
+    def test_counter_hook_logging(self):
+        # Collect event information with CounterHook and then check the logs
+        # that are emitted by CounterHook.log_results.
+
+        self.auditor.create_event("event_b", hooks=[self.hook])
+        self.auditor.create_event("event_a", hooks=[self.hook])
+        self.auditor.create_event("event_c", hooks=[self.hook])
+
+        with self.auditor.audit():
+            for _ in range(904):
+                self.auditor.raise_event("event_b")
+            for _ in range(441):
+                self.auditor.raise_event("event_a")
+            for _ in range(58):
+                self.auditor.raise_event("event_c")
+
+        self.auditor.log_results()
+        lines = self.logging_output.getvalue().rstrip().split("\n")
+        self.assertEqual(len(lines), 4)
+        self.assertEqual(lines[0], "(INFO) Calls to events recorded by CounterHook:")
+        self.assertEqual(lines[1], "(INFO)     event_a: 441")
+        self.assertEqual(lines[2], "(INFO)     event_b: 904")
+        self.assertEqual(lines[3], "(INFO)     event_c: 58")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Log results for events in CounterHook, TimerHook, and FileOpenHook by
sorting events by name.

Closes #18.