### PR TITLE
Fix error in ProfileHook.get_stats; small improvements to hook tests.

### DIFF
--- a/test/base.py
+++ b/test/base.py
@@ -2,13 +2,12 @@
 
 import logging
 import typing as t
-import unittest
 from io import StringIO
 from seagrass import Auditor
-from seagrass.base import ProtoHook
+from seagrass.base import ProtoHook, LogResultsHook
 
 
-class SeagrassTestCaseBase(unittest.TestCase):
+class SeagrassTestCaseMixin:
 
     logging_output: StringIO
     logger: logging.Logger
@@ -32,12 +31,20 @@ class SeagrassTestCaseBase(unittest.TestCase):
         self.auditor = Auditor(logger=self.logger)
 
 
-class HookTestCaseBase(SeagrassTestCaseBase):
+class HookTestCaseMixin(SeagrassTestCaseMixin):
     """A base testing class for auditor hooks."""
 
     hook: ProtoHook
     hook_gen: t.Callable[[], ProtoHook]
+    check_is_log_results_hook: bool = False
 
     def setUp(self):
         super().setUp()
         self.hook = self.hook_gen()
+
+    def test_hook_satisfies_interfaces(self):
+        CheckableProtoHook = t.runtime_checkable(ProtoHook)
+        self.assertTrue(isinstance(self.hook, CheckableProtoHook))
+
+        if self.check_is_log_results_hook:
+            self.assertTrue(isinstance(self.hook, LogResultsHook))

--- a/test/hooks/test_counter_hook.py
+++ b/test/hooks/test_counter_hook.py
@@ -1,13 +1,14 @@
 # Tests for the CounterHook auditing hook.
 
 from seagrass.hooks import CounterHook
-from test.base import HookTestCaseBase
+from test.base import HookTestCaseMixin
 import unittest
 
 
-class CounterHookTestCase(HookTestCaseBase):
+class CounterHookTestCase(HookTestCaseMixin, unittest.TestCase):
 
     hook_gen = CounterHook
+    check_is_log_results_hook = True
 
     def test_hook_function(self):
         @self.auditor.decorate("test.say_hello", hooks=[self.hook])

--- a/test/hooks/test_file_open_hook.py
+++ b/test/hooks/test_file_open_hook.py
@@ -2,11 +2,13 @@
 
 import tempfile
 import unittest
-from test.base import HookTestCaseBase
+from test.base import HookTestCaseMixin
 from seagrass.hooks import FileOpenHook
 
 
-class FileOpenHookTestCase(HookTestCaseBase):
+class FileOpenHookTestCase(HookTestCaseMixin, unittest.TestCase):
+
+    check_is_log_results_hook = True
 
     # We set track_nested_opens = True so that if we call open() in an event that's
     # nested in another event, we will count the open() for both events.

--- a/test/hooks/test_profiler_hook.py
+++ b/test/hooks/test_profiler_hook.py
@@ -1,12 +1,19 @@
 # Tests for ProfilerHook
 
-from seagrass import Auditor
-from seagrass.hooks import ProfilerHook
 import time
 import unittest
+from test.base import HookTestCaseMixin
+from seagrass.hooks import ProfilerHook
 
 
-class ProfilerHookTestCase(unittest.TestCase):
+class ProfilerHookTestCase(HookTestCaseMixin, unittest.TestCase):
+
+    check_is_log_results_hook = True
+
+    @staticmethod
+    def hook_gen():
+        return ProfilerHook(sort_keys="cumtime", restrictions=0.1)
+
     def test_hook_function(self):
         # Test only works for Python >= 3.9 due to the use of StatsProfile
         try:
@@ -14,34 +21,32 @@ class ProfilerHookTestCase(unittest.TestCase):
         except ImportError:
             self.skipTest("Test disabled for Python < 3.9")
 
-        auditor = Auditor()
-        hook = ProfilerHook()
-
         # Note: could just as easily use auditor.wrap(time.sleep, ...) here
         # but the name of time.sleep is slightly mangled in the resulting
         # StatsProfile that we generate, which complicates testing.
-        @auditor.decorate("test.sleep", hooks=[hook])
+        @self.auditor.decorate("test.sleep", hooks=[self.hook])
         def ausleep(*args):
             time.sleep(*args)
 
-        with auditor.audit():
+        self.assertEqual(self.hook.get_stats(), None)
+
+        with self.auditor.audit():
             for _ in range(10):
                 ausleep(0.001)
 
         # Get profiler information for ausleep
-        stats_profile = hook.get_stats().get_stats_profile()
+        stats_profile = self.hook.get_stats().get_stats_profile()
         ausleep_profile = stats_profile.func_profiles["ausleep"]
         self.assertEqual(ausleep_profile.ncalls, "10")
 
         # Profiler information should be reset after hook.reset() is called
-        hook.reset()
-        with self.assertRaises(Exception):
-            hook.get_stats()
+        self.hook.reset()
+        self.assertEqual(self.hook.get_stats(), None)
 
-        with auditor.audit():
+        with self.auditor.audit():
             ausleep(0.01)
 
-        stats_profile = hook.get_stats().get_stats_profile()
+        stats_profile = self.hook.get_stats().get_stats_profile()
         ausleep_profile = stats_profile.func_profiles["ausleep"]
         self.assertEqual(ausleep_profile.ncalls, "1")
         self.assertAlmostEqual(ausleep_profile.cumtime, 0.01, delta=0.005)

--- a/test/hooks/test_timer_hook.py
+++ b/test/hooks/test_timer_hook.py
@@ -2,13 +2,14 @@
 
 import time
 import unittest
-from test.base import HookTestCaseBase
+from test.base import HookTestCaseMixin
 from seagrass.hooks import TimerHook
 
 
-class TimerHookTestCase(HookTestCaseBase):
+class TimerHookTestCase(HookTestCaseMixin, unittest.TestCase):
 
     hook_gen = TimerHook
+    check_is_log_results_hook = True
 
     def test_hook_function(self):
         ausleep = self.auditor.wrap(time.sleep, "test.time.sleep", hooks=[self.hook])

--- a/test/test_auditor.py
+++ b/test/test_auditor.py
@@ -5,7 +5,7 @@ import unittest
 from io import StringIO
 from seagrass import Auditor
 from seagrass.errors import EventNotFoundError
-from test.base import SeagrassTestCaseBase
+from test.base import SeagrassTestCaseMixin
 
 
 class CreateAuditorTestCase(unittest.TestCase):
@@ -58,7 +58,7 @@ class CreateAuditorTestCase(unittest.TestCase):
             self._clear_logging_output()
 
 
-class SimpleAuditorFunctionsTestCase(SeagrassTestCaseBase):
+class SimpleAuditorFunctionsTestCase(SeagrassTestCaseMixin, unittest.TestCase):
     def test_define_new_event(self):
         # Define a new event and ensure that it gets added to the auditor's events
         # dictionary and event_wrapper dictionary


### PR DESCRIPTION
Changes to ProfileHook:

- Rename ProfileHook.profiler to ProfileHook.profile to match up with
  the name of the corresponding cProfile class (cProfile.Profile).
- Modify ProfileHook.get_stats to return None if no samples have been
  collected. Previously, we would just try to create a pstats.Stats
  object out of the internal Profile, which would raise a TypeError if
  we hadn't collected any data.
- Modify ProfileHook.log_results so that if get_stats returns None, we
  print that no samples were collected.

Changes to testing:

- Convert SeagrassTestCaseBase and HookTestCaseBase to mixin classes,
  and rename them to SeagrassTestCaseMixin and HookTestCaseMixin,
  respectively. This allows us to add tests to these two classes but
  only run the test cases in children that use the mixins.
- Add a test case to HookTestCaseMixin that checks that the hook that's
  created during setup actually satisfies the ProtoHook interface.
  Additionally, if check_if_log_results_hook is set, we check whether
  the hook satisfies the LogResultsHook interface.

Closes #22.