### PR TITLE
Stop requiring reset() to be defined for ProtoHooks.

### DIFF
--- a/docs/source/tips_and_tricks.rst
+++ b/docs/source/tips_and_tricks.rst
@@ -46,8 +46,6 @@ with the new one:
    ...         print(f"{self.__class__.__name__}: {event} triggered")
    ...     def posthook(self, event, result, context):
    ...         pass
-   ...     def reset(self):
-   ...         pass
 
    >>> hooks = [PrintEventHook()]
 

--- a/seagrass/base.py
+++ b/seagrass/base.py
@@ -111,7 +111,7 @@ the default priority ``{DEFAULT_POSTHOOK_PRIORITY=}`` is used.
 
 
 @t.runtime_checkable
-class LogResultsHook(t.Protocol):
+class LogResultsHook(ProtoHook[C], t.Protocol[C]):
     """A protocol class for hooks that support an additional `log_results` method that
     outputs the results of the hook."""
 
@@ -126,8 +126,39 @@ class LogResultsHook(t.Protocol):
 
 
 @t.runtime_checkable
-class ResettableHook(t.Protocol):
-    """A protocol class for hooks that can be reset."""
+class ResettableHook(ProtoHook[C], t.Protocol[C]):
+    """A protocol class for hooks that can be reset.
+
+    **Examples:** here is a minimal example of a Seagrass hook that satisfies the
+    ``ResettableHook`` interface. Every time the event ``"my_event"`` is raised,
+    the hook prints the number of times the event has been raised so far and
+    increments its counter.
+
+    .. doctest::
+
+       >>> from seagrass.base import ResettableHook
+
+       >>> class PrintEventHook:
+       ...     def __init__(self):
+       ...         self.reset()
+       ...
+       ...     def prehook(self, event_name, *args):
+       ...         if event_name == "my_event":
+       ...             self.event_counter += 1
+       ...             print(f"my_event has be raised {self.event_counter} times")
+       ...
+       ...     def posthook(self, *args):
+       ...         pass
+       ...
+       ...     def reset(self):
+       ...         self.event_counter = 0
+       ...
+
+       >>> hook = PrintEventHook()
+
+       >>> isinstance(hook, ResettableHook)
+       True
+    """
 
     def reset(self) -> None:
         """Reset the internal state of the hook."""

--- a/seagrass/base.py
+++ b/seagrass/base.py
@@ -29,9 +29,6 @@ class ProtoHook(t.Protocol[C]):
         ...
         ...     def posthook(self, event_name, result, context):
         ...         pass
-        ...
-        ...     def reset(self):
-        ...         pass
 
         >>> @auditor.decorate("event.say_hello", hooks=[TypeCheckHook()])
         ... def say_hello(name: str):
@@ -67,9 +64,6 @@ class ProtoHook(t.Protocol[C]):
         :param Any result: The value that was returned by the event's wrapped function.
         :param C context: The context that was returned by the original call to ``prehook``.
         """
-
-    def reset(self) -> None:
-        """Resets the internal state of the hook, if there is any."""
 
 
 def prehook_priority(hook: ProtoHook) -> int:
@@ -129,3 +123,11 @@ class LogResultsHook(t.Protocol):
 
         :param logging.Logger logger: the logger that should be used to output results.
         """
+
+
+@t.runtime_checkable
+class ResettableHook(t.Protocol):
+    """A protocol class for hooks that can be reset."""
+
+    def reset(self) -> None:
+        """Reset the internal state of the hook."""

--- a/seagrass/base.py
+++ b/seagrass/base.py
@@ -111,7 +111,7 @@ the default priority ``{DEFAULT_POSTHOOK_PRIORITY=}`` is used.
 
 
 @t.runtime_checkable
-class LogResultsHook(ProtoHook[C], t.Protocol[C]):
+class LogResultsHook(t.Protocol):
     """A protocol class for hooks that support an additional `log_results` method that
     outputs the results of the hook."""
 
@@ -126,7 +126,7 @@ class LogResultsHook(ProtoHook[C], t.Protocol[C]):
 
 
 @t.runtime_checkable
-class ResettableHook(ProtoHook[C], t.Protocol[C]):
+class ResettableHook(t.Protocol):
     """A protocol class for hooks that can be reset.
 
     **Examples:** here is a minimal example of a Seagrass hook that satisfies the

--- a/seagrass/hooks/counter_hook.py
+++ b/seagrass/hooks/counter_hook.py
@@ -24,5 +24,10 @@ class CounterHook:
 
     def log_results(self, logger: logging.Logger) -> None:
         logger.info("Calls to events recorded by %s:", self.__class__.__name__)
+
+        if len(self.event_counter) == 0:
+            logger.info("    (no events recorded)")
+            return
+
         for event in sorted(self.event_counter):
             logger.info("    %s: %d", event, self.event_counter[event])

--- a/test/base.py
+++ b/test/base.py
@@ -4,7 +4,7 @@ import logging
 import typing as t
 from io import StringIO
 from seagrass import Auditor
-from seagrass.base import ProtoHook, LogResultsHook
+from seagrass.base import ProtoHook, LogResultsHook, ResettableHook
 
 
 class SeagrassTestCaseMixin:
@@ -35,16 +35,39 @@ class HookTestCaseMixin(SeagrassTestCaseMixin):
     """A base testing class for auditor hooks."""
 
     hook: ProtoHook
-    hook_gen: t.Callable[[], ProtoHook]
+    hook_gen: t.Optional[t.Callable[[], ProtoHook]] = None
+
     check_is_log_results_hook: bool = False
+    check_is_resettable_hook: bool = False
+
+    @property
+    def hook_name(self) -> str:
+        return self.hook.__class__.__name__
 
     def setUp(self):
         super().setUp()
-        self.hook = self.hook_gen()
+
+        if self.hook_gen is not None:
+            self.hook = self.hook_gen()
 
     def test_hook_satisfies_interfaces(self):
         CheckableProtoHook = t.runtime_checkable(ProtoHook)
-        self.assertTrue(isinstance(self.hook, CheckableProtoHook))
+        self.assertIsInstance(
+            self.hook,
+            CheckableProtoHook,
+            f"{self.hook_name} does not satisfy the ProtoHook interface",
+        )
 
         if self.check_is_log_results_hook:
-            self.assertTrue(isinstance(self.hook, LogResultsHook))
+            self.assertIsInstance(
+                self.hook,
+                LogResultsHook,
+                f"{self.hook_name} does not satisfy the LogResultsHook interface",
+            )
+
+        if self.check_is_resettable_hook:
+            self.assertIsInstance(
+                self.hook,
+                ResettableHook,
+                f"{self.hook_name} does not satisfy the ResettableHook interface",
+            )

--- a/test/hooks/test_counter_hook.py
+++ b/test/hooks/test_counter_hook.py
@@ -9,6 +9,7 @@ class CounterHookTestCase(HookTestCaseMixin, unittest.TestCase):
 
     hook_gen = CounterHook
     check_is_log_results_hook = True
+    check_is_resettable_hook = True
 
     def test_hook_function(self):
         @self.auditor.decorate("test.say_hello", hooks=[self.hook])

--- a/test/hooks/test_file_open_hook.py
+++ b/test/hooks/test_file_open_hook.py
@@ -9,6 +9,7 @@ from seagrass.hooks import FileOpenHook
 class FileOpenHookTestCase(HookTestCaseMixin, unittest.TestCase):
 
     check_is_log_results_hook = True
+    check_is_resettable_hook = True
 
     # We set track_nested_opens = True so that if we call open() in an event that's
     # nested in another event, we will count the open() for both events.

--- a/test/hooks/test_profiler_hook.py
+++ b/test/hooks/test_profiler_hook.py
@@ -9,6 +9,7 @@ from seagrass.hooks import ProfilerHook
 class ProfilerHookTestCase(HookTestCaseMixin, unittest.TestCase):
 
     check_is_log_results_hook = True
+    check_is_resettable_hook = True
 
     @staticmethod
     def hook_gen():

--- a/test/hooks/test_stack_trace_hook.py
+++ b/test/hooks/test_stack_trace_hook.py
@@ -6,6 +6,8 @@ from seagrass.hooks import StackTraceHook
 class StackTraceHookTestCase(unittest.TestCase):
     """Tests for the StackTraceHook auditing hook."""
 
+    check_is_resettable_hook = True
+
     def test_hook_function(self):
         auditor = Auditor()
         hook = StackTraceHook()

--- a/test/hooks/test_timer_hook.py
+++ b/test/hooks/test_timer_hook.py
@@ -10,6 +10,7 @@ class TimerHookTestCase(HookTestCaseMixin, unittest.TestCase):
 
     hook_gen = TimerHook
     check_is_log_results_hook = True
+    check_is_resettable_hook = True
 
     def test_hook_function(self):
         ausleep = self.auditor.wrap(time.sleep, "test.time.sleep", hooks=[self.hook])

--- a/test/test_auditor.py
+++ b/test/test_auditor.py
@@ -87,16 +87,13 @@ class SimpleAuditorFunctionsTestCase(SeagrassTestCaseMixin, unittest.TestCase):
 
         class TestHook:
             def __init__(self):
-                self.reset()
+                self.last_prehook_args = self.last_posthook_args = None
 
             def prehook(self, event_name, args, kwargs):
                 self.last_prehook_args = (event_name, args, kwargs)
 
             def posthook(self, event_name, result, context):
                 self.last_posthook_args = (event_name, result)
-
-            def reset(self):
-                self.last_prehook_args = self.last_posthook_args = None
 
         hook = TestHook()
         self.auditor.create_event("test.signal", hooks=[hook])
@@ -126,16 +123,13 @@ class SimpleAuditorFunctionsTestCase(SeagrassTestCaseMixin, unittest.TestCase):
 
         class MySumHook:
             def __init__(self):
-                self.reset()
+                self.cumsums = []
 
             def prehook(self, event_name, args, kwargs):
                 self.cumsums.append(args[0])
 
             def posthook(self, *args):
                 pass
-
-            def reset(self):
-                self.cumsums = []
 
         hook = MySumHook()
         self.auditor.create_event("my_sum.cumsum", hooks=[hook])

--- a/test/test_base.py
+++ b/test/test_base.py
@@ -1,10 +1,15 @@
 # Tests for protocols and functions defined in seagrass.base
 
 import seagrass.base as base
+import typing as t
 import unittest
 
 
 class CustomHookImplementationTestCase(unittest.TestCase):
+    def setUp(self):
+        # Create a version of the ProtoHook protocol that we can check at runtime.
+        self.CheckableProtoHook = t.runtime_checkable(base.ProtoHook)
+
     def test_get_prehook_and_posthook_priority(self):
         class MyHook:
             prehook_priority: int = 7
@@ -15,10 +20,12 @@ class CustomHookImplementationTestCase(unittest.TestCase):
             def posthook(self, *args):
                 ...
 
-            def reset(self):
-                ...
-
         hook = MyHook()
+        self.assertIsInstance(
+            hook,
+            self.CheckableProtoHook,
+            f"{hook.__class__.__name__} does not satisfy the hooking protocol",
+        )
         self.assertEqual(base.prehook_priority(hook), 7)
         self.assertEqual(base.posthook_priority(hook), base.DEFAULT_POSTHOOK_PRIORITY)
 


### PR DESCRIPTION
Remove reset() as a method from the ProtoHook interface, and create a
new interface ResettableHook that requires this method. New hooks are no
longer required to implement reset(), but will need to in order to be
reset by the auditor.

Other updates:
- Add auditor.reset_hooks() to reset all hooks that satisfy
  ResettableHook.
- Add two new keyword arguments to auditor.audit():
  - reset_hooks: reset hooks before leaving the auditing context.
  - log_results: log results before leaving the auditing context.
- Add new tests to check whether hooks satisfy the ResettableHook
  interface.

Closes #28.