### PR TITLE
Rename Auditor.wraps, Auditor.decorate, and Auditor.audit.

### DIFF
--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -55,7 +55,7 @@ can use Seagrass as a thin layer around ``sys.audit`` by passing
 
 .. testcode:: raise-runtime-events
 
-   @auditor.decorate("foo_event", raise_runtime_events=True)
+   @auditor.audit("foo_event", raise_runtime_events=True)
    def foo(x, y, z=0):
        return x + y + z
 
@@ -87,7 +87,7 @@ these events is raised, along with the arguments passed to ``sys.audit``:
 
    >>> sys.addaudithook(foo_event_hook)
 
-   >>> with auditor.audit():
+   >>> with auditor.start_auditing():
    ...     result = foo(1, 2, z=3)
    prehook called: args=(1, 2), kwargs={'z': 3}
    posthook called: result=6

--- a/docs/source/glossary.rst
+++ b/docs/source/glossary.rst
@@ -27,7 +27,7 @@ new auditing context using :py:meth:`seagrass.Auditor.audit`:
 
    auditor = seagrass.Auditor()
 
-   with auditor.audit():
+   with auditor.start_auditing():
        # Events that occur here will be audited
        ...
 
@@ -53,8 +53,8 @@ Event
 Also referred to as an *audit event*. Events (that is, instances of
 :py:class:`seagrass.events.Event`) are the basic building block for auditing
 code in Seagrass. You usually create an event with the list of hooks that you
-want to run on that event using the ``@auditor.decorate`` or ``auditor.wrap``
-methods of :py:class:`seagrass.Auditor`:
+want to run on that event using the :py:meth:`~seagrass.Auditor.audit` method of
+:py:class:`seagrass.Auditor`:
 
 .. testsetup::
 
@@ -64,20 +64,20 @@ methods of :py:class:`seagrass.Auditor`:
 
 .. testcode::
 
-   # Method 1: use @auditor.decorate to decorate a function definition.
-   # This call will create a new event called "my_foo_event" whenever
-   # we call the function foo
-   @auditor.decorate("my_foo_event", hooks=hooks)
+   # Method 1: use @auditor.audit to decorate a function definition.
+   # This call will create a new event called "my_foo_event" that gets
+   # raised whenever we call the function foo
+   @auditor.audit("my_foo_event", hooks=hooks)
    def foo(x, y):
        return x + y
 
-   # Method 2: use auditor.wrap to wrap an existing function.
-   # This call will create a new event called "my_bar_event" whenever
-   # we call the function audited_bar
+   # Method 2: use auditor.audit to wrap an existing function.
+   # This call will create a new event called "my_bar_event" that gets
+   # raised whenever we call the function audited_bar
    def bar(name):
        return f"Hello, {name}!"
 
-   audited_bar = auditor.wrap(bar, "my_bar_event", hooks=hooks)
+   audited_bar = auditor.audit("my_bar_event", bar, hooks=hooks)
 
 There are two main components to any event:
 
@@ -93,11 +93,11 @@ There are two main components to any event:
  
   .. doctest::
  
-     >>> @auditor.decorate("my_event", hooks=hooks)
+     >>> @auditor.audit("my_event", hooks=hooks)
      ... def add(x, y):
      ...     return x + y
  
-     >>> @auditor.decorate("my_event", hooks=hooks)
+     >>> @auditor.audit("my_event", hooks=hooks)
      ... def sub(x, y):
      ...     return x - y   # doctest: +IGNORE_EXCEPTION_DETAIL
      Traceback (most recent call last):

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -21,9 +21,9 @@ Creating a new Auditor
 You typically audit code with Seagrass in three steps:
 
 1. Create a new ``Auditor`` instance.
-2. Define new Seagrass events using ``Auditor.decorate`` or ``Auditor.wraps``.
-3. Create a new auditing context using ``auditor.audit()``, and then start
-   calling the code under audit.
+2. Define new Seagrass events using ``Auditor.audit``.
+3. Create a new auditing context using ``auditor.start_auditing()``, and then
+   start calling the code under audit.
 
 Let's look at an example. Before we start, we'll configure the logger used by
 Seagrass. Auditors default to using the ``"seagrass"`` logger, so we'll 
@@ -76,16 +76,16 @@ function called ``event.sub``.
    hook = CounterHook()
 
    # Now define some new events by hooking some example functions
-   @auditor.decorate("event.add", hooks=[hook])
+   @auditor.audit("event.add", hooks=[hook])
    def add(x: int, y: int) -> int:
        return x + y
 
-   @auditor.decorate("event.sub", hooks=[hook])
+   @auditor.audit("event.sub", hooks=[hook])
    def sub(x: int, y: int) -> int:
        return x - y
 
    # Now start auditing!
-   with auditor.audit():
+   with auditor.start_auditing():
        add(1, 2)
        add(3, 4)
        sub(5, 2)
@@ -109,9 +109,9 @@ spent in that function (as well as the number of times it gets called).
    >>> from seagrass.hooks import CounterHook, TimerHook
    >>> ch = CounterHook()
    >>> th = TimerHook()
-   >>> ausleep = auditor.wrap(time.sleep, "time.sleep", hooks=[ch,th])
+   >>> ausleep = auditor.audit("time.sleep", time.sleep, hooks=[ch,th])
    >>> time.sleep = ausleep
-   >>> with auditor.audit():
+   >>> with auditor.start_auditing():
    ...     for _ in range(10):
    ...         time.sleep(0.1)
    >>> auditor.log_results()  # doctest: +SKIP
@@ -125,10 +125,10 @@ Raising audit events without wrapping functions
 -----------------------------------------------
 
 Up until this point, we've been creating audit events by calling
-:py:meth:`seagrass.Auditor.decorate` and :py:meth:`seagrass.Auditor.wrap` on a
-function that we want to audit. Sometimes, though, it doesn't make sense to
-audit an entire function; perhaps we just want to raise a signal at a single
-point in time, and have Seagrass capture information about that signal.
+:py:meth:`seagrass.Auditor.audit` function that we want to audit. Sometimes,
+though, it doesn't make sense to audit an entire function; perhaps we just want
+to raise a signal at a single point in time, and have Seagrass capture
+information about that signal.
 
 We can achieve this functionality by using
 :py:meth:`~seagrass.Auditor.create_event` and
@@ -169,7 +169,7 @@ new event ``my_sum.cumsum`` and call it at every iteration of the function
    ...         total += val
    ...     return total
 
-   >>> with auditor.audit():
+   >>> with auditor.start_auditing():
    ...     my_sum([1, 2, 3, 4])
    (DEBUG) seagrass: cumsum=0.0
    (DEBUG) seagrass: cumsum=1.0

--- a/docs/source/tips_and_tricks.rst
+++ b/docs/source/tips_and_tricks.rst
@@ -49,11 +49,11 @@ with the new one:
 
    >>> hooks = [PrintEventHook()]
 
-   >>> aunorm = auditor.wrap(Point2D.norm, "event.norm", hooks=hooks)
+   >>> aunorm = auditor.audit("event.norm", Point2D.norm, hooks=hooks)
 
    >>> Point2D.norm = aunorm
 
-   >>> with auditor.audit():
+   >>> with auditor.start_auditing():
    ...     p = Point2D(3, 4)
    ...     print(f"{p.norm()=}")
    PrintEventHook: event.norm triggered
@@ -71,15 +71,15 @@ getter, setter, and deleter methods for that property.
 
    >>> getter_hooks = setter_hooks = deleter_hooks = [PrintEventHook()]
 
-   >>> @auditor.decorate("point2d.get_x", hooks=getter_hooks)
+   >>> @auditor.audit("point2d.get_x", hooks=getter_hooks)
    ... def get_x(self):
    ...     return self.__x
 
-   >>> @auditor.decorate("point2d.set_x", hooks=setter_hooks)
+   >>> @auditor.audit("point2d.set_x", hooks=setter_hooks)
    ... def set_x(self, val):
    ...     self.__x = val
 
-   >>> @auditor.decorate("point2d.del_x", hooks=deleter_hooks)
+   >>> @auditor.audit("point2d.del_x", hooks=deleter_hooks)
    ... def del_x(self):
    ...     del self.__x
 
@@ -113,7 +113,7 @@ getter, setter, and/or deleter methods of the old property.
    >>> isinstance(Point2D.tuple, property)
    True
 
-   >>> aufget = auditor.wrap(Point2D.tuple.fget, "tuple_getter", hooks=hooks)
+   >>> aufget = auditor.audit("tuple_getter", Point2D.tuple.fget, hooks=hooks)
 
    >>> new_prop = property(
    ...     fget=aufget, fset=Point2D.tuple.fset, fdel=Point2D.tuple.fdel,
@@ -121,7 +121,7 @@ getter, setter, and/or deleter methods of the old property.
 
    >>> setattr(Point2D, "tuple", new_prop)
 
-   >>> with auditor.audit():
+   >>> with auditor.start_auditing():
    ...     p = Point2D(3, 4)
    ...     print(p.tuple)
    PrintEventHook: tuple_getter triggered
@@ -151,7 +151,7 @@ getter, setter, and/or deleter methods of the old property.
 
    .. doctest::
 
-      >>> aufget = auditor.wrap(Point2D.tuple.fget, "tuple_getter", hooks=hooks)
+      >>> aufget = auditor.audit("tuple_getter", Point2D.tuple.fget, hooks=hooks)
 
       >>> setattr(Point2D.tuple, "fget", aufget) # doctest: +IGNORE_EXCEPTION_DETAIL
       Traceback (most recent call last):

--- a/seagrass/base.py
+++ b/seagrass/base.py
@@ -30,11 +30,11 @@ class ProtoHook(t.Protocol[C]):
         ...     def posthook(self, event_name, result, context):
         ...         pass
 
-        >>> @auditor.decorate("event.say_hello", hooks=[TypeCheckHook()])
+        >>> @auditor.audit("event.say_hello", hooks=[TypeCheckHook()])
         ... def say_hello(name: str):
         ...     return f"Hello, {name}!"
 
-        >>> with auditor.audit():
+        >>> with auditor.start_auditing():
         ...     say_hello("Alice")
         ...     say_hello(0)    # Should raise AssertionError   # doctest: +IGNORE_EXCEPTION_DETAIL
         Traceback (most recent call last):

--- a/seagrass/hooks/logging_hook.py
+++ b/seagrass/hooks/logging_hook.py
@@ -22,8 +22,10 @@ class LoggingHook:
     ) -> None:
         if prehook_msg is None and posthook_msg is None:
             raise ValueError(
-                "At least one of the keyword arguments prehook_msg and posthook_msg "
-                + "must be specified and not equal to None"
+                (
+                    "At least one of the keyword arguments prehook_msg and posthook_msg "
+                    "must be specified and not equal to None"
+                )
             )
 
         self.prehook_msg = prehook_msg

--- a/seagrass/hooks/profiler_hook.py
+++ b/seagrass/hooks/profiler_hook.py
@@ -74,14 +74,14 @@ class ProfilerHook:
 
         .. _pstats.Stats: https://docs.python.org/3/library/profile.html#pstats.Stats
         """
-        if self.profile.getstats() == []:   # type: ignore
+        if self.profile.getstats() == []:  # type: ignore
             return None
         else:
             return pstats.Stats(self.profile, **kwargs)
 
     def reset(self) -> None:
         """Reset the internal profiler."""
-        self.profile.clear()    # type: ignore
+        self.profile.clear()  # type: ignore
 
     def log_results(self, logger: logging.Logger) -> None:
         """Log the results captured by ProfilerHook."""

--- a/test/hooks/test_counter_hook.py
+++ b/test/hooks/test_counter_hook.py
@@ -12,7 +12,7 @@ class CounterHookTestCase(HookTestCaseMixin, unittest.TestCase):
     check_is_resettable_hook = True
 
     def test_hook_function(self):
-        @self.auditor.decorate("test.say_hello", hooks=[self.hook])
+        @self.auditor.audit("test.say_hello", hooks=[self.hook])
         def say_hello(name: str) -> str:
             return f"Hello, {name}!"
 
@@ -22,7 +22,7 @@ class CounterHookTestCase(HookTestCaseMixin, unittest.TestCase):
         say_hello("Alice")
         self.assertEqual(self.hook.event_counter["test.say_hello"], 0)
 
-        with self.auditor.audit():
+        with self.auditor.start_auditing():
             for name in ("Alice", "Bob", "Cathy"):
                 say_hello(name)
         self.assertEqual(self.hook.event_counter["test.say_hello"], 3)
@@ -40,7 +40,7 @@ class CounterHookTestCase(HookTestCaseMixin, unittest.TestCase):
         self.auditor.create_event("event_a", hooks=[self.hook])
         self.auditor.create_event("event_c", hooks=[self.hook])
 
-        with self.auditor.audit():
+        with self.auditor.start_auditing():
             for _ in range(904):
                 self.auditor.raise_event("event_b")
             for _ in range(441):

--- a/test/hooks/test_logger_hook.py
+++ b/test/hooks/test_logger_hook.py
@@ -28,7 +28,7 @@ class LoggingHookTestCase(HookTestCaseMixin, unittest.TestCase):
     def test_hook_function(self):
         event = "test.multiply_or_add"
 
-        @self.auditor.decorate(event, hooks=[self.hook_pre, self.hook_both])
+        @self.auditor.audit(event, hooks=[self.hook_pre, self.hook_both])
         def multiply_or_add(*args, op="*"):
             if op == "*":
                 return reduce(mul, args, 1)
@@ -39,7 +39,7 @@ class LoggingHookTestCase(HookTestCaseMixin, unittest.TestCase):
 
         args = (1, 2, 3, 4)
         kwargs_add = {"op": "+"}
-        with self.auditor.audit():
+        with self.auditor.start_auditing():
             multiply_or_add(*args)
             multiply_or_add(*args, **kwargs_add)
 

--- a/test/hooks/test_profiler_hook.py
+++ b/test/hooks/test_profiler_hook.py
@@ -22,16 +22,16 @@ class ProfilerHookTestCase(HookTestCaseMixin, unittest.TestCase):
         except ImportError:
             self.skipTest("Test disabled for Python < 3.9")
 
-        # Note: could just as easily use auditor.wrap(time.sleep, ...) here
-        # but the name of time.sleep is slightly mangled in the resulting
+        # Note: could just as easily use auditor.audit("test.sleep", time.sleep, ...)
+        # here but the name of time.sleep is slightly mangled in the resulting
         # StatsProfile that we generate, which complicates testing.
-        @self.auditor.decorate("test.sleep", hooks=[self.hook])
+        @self.auditor.audit("test.sleep", hooks=[self.hook])
         def ausleep(*args):
             time.sleep(*args)
 
         self.assertEqual(self.hook.get_stats(), None)
 
-        with self.auditor.audit():
+        with self.auditor.start_auditing():
             for _ in range(10):
                 ausleep(0.001)
 
@@ -44,7 +44,7 @@ class ProfilerHookTestCase(HookTestCaseMixin, unittest.TestCase):
         self.hook.reset()
         self.assertEqual(self.hook.get_stats(), None)
 
-        with self.auditor.audit():
+        with self.auditor.start_auditing():
             ausleep(0.01)
 
         stats_profile = self.hook.get_stats().get_stats_profile()

--- a/test/hooks/test_stack_trace_hook.py
+++ b/test/hooks/test_stack_trace_hook.py
@@ -12,15 +12,15 @@ class StackTraceHookTestCase(unittest.TestCase):
         auditor = Auditor()
         hook = StackTraceHook()
 
-        @auditor.decorate("test.foo", hooks=[hook])
+        @auditor.audit("test.foo", hooks=[hook])
         def foo():
             return
 
-        @auditor.decorate("test.bar", hooks=[hook])
+        @auditor.audit("test.bar", hooks=[hook])
         def bar():
             return foo()
 
-        with auditor.audit():
+        with auditor.start_auditing():
             foo()
             bar()
 

--- a/test/hooks/test_timer_hook.py
+++ b/test/hooks/test_timer_hook.py
@@ -13,10 +13,10 @@ class TimerHookTestCase(HookTestCaseMixin, unittest.TestCase):
     check_is_resettable_hook = True
 
     def test_hook_function(self):
-        ausleep = self.auditor.wrap(time.sleep, "test.time.sleep", hooks=[self.hook])
+        ausleep = self.auditor.audit("test.time.sleep", time.sleep, hooks=[self.hook])
 
         ausleep(0.01)
-        with self.auditor.audit():
+        with self.auditor.start_auditing():
             ausleep(0.01)
         ausleep(0.01)
 

--- a/test/test_auditor.py
+++ b/test/test_auditor.py
@@ -62,7 +62,7 @@ class SimpleAuditorFunctionsTestCase(SeagrassTestCaseMixin, unittest.TestCase):
     def test_define_new_event(self):
         # Define a new event and ensure that it gets added to the auditor's events
         # dictionary and event_wrapper dictionary
-        @self.auditor.decorate("test.foo")
+        @self.auditor.audit("test.foo")
         def foo():
             return
 
@@ -70,13 +70,13 @@ class SimpleAuditorFunctionsTestCase(SeagrassTestCaseMixin, unittest.TestCase):
         self.assertIn("test.foo", self.auditor.event_wrappers)
 
     def test_define_two_events_with_the_same_name(self):
-        @self.auditor.decorate("test.foo")
+        @self.auditor.audit("test.foo")
         def foo_1():
             return
 
         with self.assertRaises(ValueError):
 
-            @self.auditor.decorate("test.foo")
+            @self.auditor.audit("test.foo")
             def foo_2():
                 return
 
@@ -103,7 +103,7 @@ class SimpleAuditorFunctionsTestCase(SeagrassTestCaseMixin, unittest.TestCase):
         self.assertEqual(hook.last_prehook_args, None)
         self.assertEqual(hook.last_posthook_args, None)
 
-        with self.auditor.audit():
+        with self.auditor.start_auditing():
             self.auditor.raise_event("test.signal", 1, 2, name="Alice")
 
         self.assertEqual(
@@ -134,7 +134,7 @@ class SimpleAuditorFunctionsTestCase(SeagrassTestCaseMixin, unittest.TestCase):
         hook = MySumHook()
         self.auditor.create_event("my_sum.cumsum", hooks=[hook])
 
-        with self.auditor.audit():
+        with self.auditor.start_auditing():
             my_sum(1, 2, 3, 4)
 
         self.assertEqual(hook.cumsums, [0.0, 1.0, 3.0, 6.0])

--- a/tox.ini
+++ b/tox.ini
@@ -50,6 +50,7 @@ addopts = -rsf
 
 [flake8]
 max-line-length = 120
+ignore = F811
 exclude =
     # From .gitignore
     dist,


### PR DESCRIPTION
**Breaking changes:**

- Rename the original Auditor.audit function to Auditor.start_auditing.
- Merge Auditor.wraps and Auditor.decorate into a single function,
  Auditor.audit. This helps clarify that these two functions are
  essentially the same, and establishes a more "obvious" method name
  (whereas "decorate" and "wraps" were not so obvious).