### PR TITLE
Add the CleanupHook interface.

### DIFF
--- a/seagrass/base.py
+++ b/seagrass/base.py
@@ -162,3 +162,18 @@ class ResettableHook(t.Protocol):
 
     def reset(self) -> None:
         """Reset the internal state of the hook."""
+
+
+@t.runtime_checkable
+class CleanupHook(ProtoHook[C], t.Protocol[C]):
+    """A protocol class for hooks that have a 'cleanup' stage.
+
+    Hooks that implement this interface are unconditionally 'cleaned up' after an event if their
+    prehook was run during that event. Hooks that modify their internal state or create other
+    side effects that need to be reset after the event is finished executing should implement
+    this interface, in case an exception is thrown during the course of the event.
+    """
+
+    def cleanup(self, event_name: str, context: C):
+        """Perform the hook's cleanup stage. The ``event_name`` and ``context`` are the same as
+        those used by the ``posthook`` function."""

--- a/seagrass/errors.py
+++ b/seagrass/errors.py
@@ -1,5 +1,8 @@
 # Basic errors that can be thrown while using Seagrass
 
+import os
+import typing as t
+
 
 class SeagrassError(Exception):
     """A generic error for the Seagrass library."""
@@ -18,4 +21,21 @@ class EventNotFoundError(SeagrassError):
         """
         self.event_name = event_name
         msg = f"Audit event not found: {event_name}"
-        super(Exception, self).__init__(msg)
+        super().__init__(msg)
+
+
+class PosthookError(SeagrassError):
+    """Raised when one or more Seagrass posthooks raised an error."""
+
+    errors: t.List[Exception]
+
+    def __init__(self, errors: t.List[Exception]) -> None:
+        """Create a new PosthookError.
+
+        :param List[Exception] errors: a list of errors that were raised.
+        """
+        self.errors = errors
+        msg = f"{len(errors)} errors raised while processing posthooks and clean-up stages."
+        msg += os.linesep
+        msg += os.linesep.join(f"{e.__class__.__name__}: {e}" for e in errors)
+        super().__init__(msg)

--- a/seagrass/hooks/file_open_hook.py
+++ b/seagrass/hooks/file_open_hook.py
@@ -68,6 +68,10 @@ class FileOpenHook:
         result: t.Any,
         context: None,
     ) -> None:
+        # Do nothing -- we defer fixing the __current_event_stack to the cleanup stage
+        pass
+
+    def cleanup(self, event_name: str, context: None) -> None:
         self.__current_event_stack.pop()
 
     def reset(self) -> None:

--- a/seagrass/hooks/profiler_hook.py
+++ b/seagrass/hooks/profiler_hook.py
@@ -61,6 +61,10 @@ class ProfilerHook:
         self.profile.enable()
 
     def posthook(self, event_name: str, result: t.Any, context: None) -> None:
+        # Do nothing -- we defer disabling profiling to the cleanup stage
+        pass
+
+    def cleanup(self, event_name: str, context: None) -> None:
         # Stop profiling
         self.profile.disable()
 

--- a/test/base/__init__.py
+++ b/test/base/__init__.py
@@ -1,0 +1,1 @@
+# flake8: noqa: F401

--- a/test/base/test_cleanup_hook.py
+++ b/test/base/test_cleanup_hook.py
@@ -1,0 +1,150 @@
+# Tests for hook satisfying the CleanupHook interface.
+
+import unittest
+from seagrass.base import CleanupHook, ResettableHook
+from seagrass.errors import PosthookError
+from test.utils import SeagrassTestCaseMixin
+
+
+class CleanupHookTestCase(SeagrassTestCaseMixin, unittest.TestCase):
+    """Tests to check that the cleanup stage of hooks that satisfy the CleanupHook interface
+    is unconditionally executed."""
+
+    class _BaseTestHook:
+        def __init__(self):
+            self.reset()
+
+        def prehook(self, *args):
+            pass
+
+        def reset(self):
+            self.counter = 0
+
+    class _HookA(_BaseTestHook):
+        # Regular hook with no cleanup stage
+        def posthook(self, *args):
+            self.counter += 1
+
+    class _HookB(_BaseTestHook):
+        # A hook that satisfies the CleanupHook interface
+        def posthook(self, *args):
+            pass
+
+        def cleanup(self, *args):
+            self.counter += 1
+
+    class _HookC(_BaseTestHook):
+        # A hook that satisfies the CleanupHook interface, but which also raises an
+        # exception in its posthook.
+        def posthook(self, *args):
+            assert False
+
+        def cleanup(self, *args):
+            self.counter += 1
+
+    class _HookD(_BaseTestHook):
+        # A hook that satisfies the CleanupHook interface, but which also raises an
+        # exception in its prehook.
+        def prehook(self, *args):
+            assert False
+
+        def posthook(self, *args):
+            pass
+
+        def cleanup(self, *args):
+            self.counter += 1
+
+    def setUp(self):
+        super().setUp()
+        print(self.auditor)
+        self.hook_a = self._HookA()
+        self.hook_b = self._HookB()
+        self.hook_c = self._HookC()
+        self.hook_d = self._HookD()
+        self.hooks = (self.hook_a, self.hook_b, self.hook_c, self.hook_d)
+
+    def test_hooks_satisfy_interfaces(self):
+        # All of the hooks, except for _HookA, should satisfy the CleanupHook interface.
+        self.assertNotIsInstance(self.hooks[0], CleanupHook)
+        for hook in self.hooks[1:]:
+            self.assertIsInstance(hook, CleanupHook)
+
+        # All of the hook should satisfy the ResettableHook interface
+        for hook in self.hooks:
+            self.assertIsInstance(hook, ResettableHook)
+
+    def _create_test_functions(self, event_name_prefix, *hooks):
+        """Hook two test functions: one that does nothing, and other that raises a RuntimeError."""
+
+        @self.auditor.audit(f"{event_name_prefix}.no_error", hooks=hooks)
+        def no_error():
+            return
+
+        @self.auditor.audit(f"{event_name_prefix}.error", hooks=hooks)
+        def error():
+            raise RuntimeError()
+
+        return no_error, error
+
+    def test_hooks_a_and_b(self):
+        # Tests for _HookA + _HookB
+        nerr, err = self._create_test_functions("hook_ab", self.hook_a, self.hook_b)
+        with self.auditor.start_auditing(reset_hooks=True):
+            nerr()
+            self.assertEqual(self.hook_a.counter, 1)
+            self.assertEqual(self.hook_b.counter, 1)
+
+            with self.assertRaises(RuntimeError):
+                err()
+            self.assertEqual(self.hook_a.counter, 1)
+            self.assertEqual(self.hook_b.counter, 2)
+
+    def test_hooks_b_and_c(self):
+        # Tests for _HookC + _HookB
+        nerr, err = self._create_test_functions("hook_cb", self.hook_c, self.hook_b)
+        with self.auditor.start_auditing(reset_hooks=True):
+            with self.assertRaises(PosthookError):
+                nerr()
+            self.assertEqual(self.hook_b.counter, 1)
+            self.assertEqual(self.hook_c.counter, 1)
+
+            # Despite the fact that an error is raised in the posthook, we should prioritize
+            # the error that was raised by the wrapped function.
+            with self.assertRaises(RuntimeError):
+                err()
+            self.assertEqual(self.hook_b.counter, 2)
+            self.assertEqual(self.hook_c.counter, 2)
+
+    def test_hooks_b_and_d(self):
+        # Tests for _HookD + _HookB, and _HookB + _HookD
+        #
+        # For these test cases, we have to consider the fact that cleanup is only called on
+        # the hooks whose prehooks were executed. As a result:
+        # - When we call _HookD before _HookB, we error out *before* reaching _HookB's prehook, so
+        #   we never call cleanup on _HookB.
+        # - When we call _HookD after _HookB, we error out *after* reaching _HookB's prehook, so
+        #   cleanup *should* be called on _HookB.
+
+        nerr, err = self._create_test_functions("hook_db", self.hook_d, self.hook_b)
+        with self.auditor.start_auditing(reset_hooks=True):
+            with self.assertRaises(AssertionError):
+                nerr()
+            self.assertEqual(self.hook_b.counter, 0)
+            self.assertEqual(self.hook_d.counter, 0)
+
+            with self.assertRaises(AssertionError):
+                err()
+            self.assertEqual(self.hook_b.counter, 0)
+            self.assertEqual(self.hook_d.counter, 0)
+
+        nerr, err = self._create_test_functions("hook_bd", self.hook_b, self.hook_d)
+        with self.auditor.start_auditing(reset_hooks=True):
+            with self.assertRaises(AssertionError):
+                nerr()
+            self.assertEqual(self.hook_b.counter, 1)
+            self.assertEqual(self.hook_d.counter, 0)
+
+            with self.assertRaises(AssertionError):
+                err()
+            self.assertEqual(self.hook_b.counter, 2)
+            self.assertEqual(self.hook_d.counter, 0)

--- a/test/hooks/test_counter_hook.py
+++ b/test/hooks/test_counter_hook.py
@@ -1,15 +1,15 @@
 # Tests for the CounterHook auditing hook.
 
+from seagrass.base import ResettableHook, LogResultsHook
 from seagrass.hooks import CounterHook
-from test.base import HookTestCaseMixin
+from test.utils import HookTestCaseMixin
 import unittest
 
 
 class CounterHookTestCase(HookTestCaseMixin, unittest.TestCase):
 
     hook_gen = CounterHook
-    check_is_log_results_hook = True
-    check_is_resettable_hook = True
+    check_interfaces = (ResettableHook, LogResultsHook)
 
     def test_hook_function(self):
         @self.auditor.audit("test.say_hello", hooks=[self.hook])

--- a/test/hooks/test_file_open_hook.py
+++ b/test/hooks/test_file_open_hook.py
@@ -2,14 +2,14 @@
 
 import tempfile
 import unittest
-from test.base import HookTestCaseMixin
+from test.utils import HookTestCaseMixin
+from seagrass.base import LogResultsHook, ResettableHook, CleanupHook
 from seagrass.hooks import FileOpenHook
 
 
 class FileOpenHookTestCase(HookTestCaseMixin, unittest.TestCase):
 
-    check_is_log_results_hook = True
-    check_is_resettable_hook = True
+    check_interfaces = (LogResultsHook, ResettableHook, CleanupHook)
 
     # We set track_nested_opens = True so that if we call open() in an event that's
     # nested in another event, we will count the open() for both events.

--- a/test/hooks/test_logger_hook.py
+++ b/test/hooks/test_logger_hook.py
@@ -5,7 +5,7 @@ import unittest
 from functools import reduce
 from operator import add, mul
 from seagrass.hooks import LoggingHook
-from test.base import HookTestCaseMixin
+from test.utils import HookTestCaseMixin
 
 
 class LoggingHookTestCase(HookTestCaseMixin, unittest.TestCase):

--- a/test/hooks/test_profiler_hook.py
+++ b/test/hooks/test_profiler_hook.py
@@ -2,14 +2,14 @@
 
 import time
 import unittest
-from test.base import HookTestCaseMixin
+from test.utils import HookTestCaseMixin
+from seagrass.base import LogResultsHook, ResettableHook, CleanupHook
 from seagrass.hooks import ProfilerHook
 
 
 class ProfilerHookTestCase(HookTestCaseMixin, unittest.TestCase):
 
-    check_is_log_results_hook = True
-    check_is_resettable_hook = True
+    check_interfaces = (LogResultsHook, ResettableHook, CleanupHook)
 
     @staticmethod
     def hook_gen():

--- a/test/hooks/test_stack_trace_hook.py
+++ b/test/hooks/test_stack_trace_hook.py
@@ -1,12 +1,13 @@
 import unittest
 from seagrass import Auditor
+from seagrass.base import ResettableHook
 from seagrass.hooks import StackTraceHook
 
 
 class StackTraceHookTestCase(unittest.TestCase):
     """Tests for the StackTraceHook auditing hook."""
 
-    check_is_resettable_hook = True
+    check_interfaces = (ResettableHook,)
 
     def test_hook_function(self):
         auditor = Auditor()

--- a/test/hooks/test_timer_hook.py
+++ b/test/hooks/test_timer_hook.py
@@ -2,15 +2,15 @@
 
 import time
 import unittest
-from test.base import HookTestCaseMixin
+from test.utils import HookTestCaseMixin
+from seagrass.base import LogResultsHook, ResettableHook
 from seagrass.hooks import TimerHook
 
 
 class TimerHookTestCase(HookTestCaseMixin, unittest.TestCase):
 
     hook_gen = TimerHook
-    check_is_log_results_hook = True
-    check_is_resettable_hook = True
+    check_interfaces = (LogResultsHook, ResettableHook)
 
     def test_hook_function(self):
         ausleep = self.auditor.audit("test.time.sleep", time.sleep, hooks=[self.hook])

--- a/test/test_auditor.py
+++ b/test/test_auditor.py
@@ -5,7 +5,7 @@ import unittest
 from io import StringIO
 from seagrass import Auditor
 from seagrass.errors import EventNotFoundError
-from test.base import SeagrassTestCaseMixin
+from test.utils import SeagrassTestCaseMixin
 
 
 class CreateAuditorTestCase(unittest.TestCase):

--- a/test/utils.py
+++ b/test/utils.py
@@ -4,7 +4,7 @@ import logging
 import typing as t
 from io import StringIO
 from seagrass import Auditor
-from seagrass.base import ProtoHook, LogResultsHook, ResettableHook
+from seagrass.base import ProtoHook
 
 
 class SeagrassTestCaseMixin:
@@ -37,8 +37,9 @@ class HookTestCaseMixin(SeagrassTestCaseMixin):
     hook: ProtoHook
     hook_gen: t.Optional[t.Callable[[], ProtoHook]] = None
 
-    check_is_log_results_hook: bool = False
-    check_is_resettable_hook: bool = False
+    # A list of all of the interfaces that the hook is expected
+    # to satisfy.
+    check_interfaces: t.Optional[t.Tuple[t.Type, ...]] = None
 
     @property
     def hook_name(self) -> str:
@@ -58,16 +59,11 @@ class HookTestCaseMixin(SeagrassTestCaseMixin):
             f"{self.hook_name} does not satisfy the ProtoHook interface",
         )
 
-        if self.check_is_log_results_hook:
-            self.assertIsInstance(
-                self.hook,
-                LogResultsHook,
-                f"{self.hook_name} does not satisfy the LogResultsHook interface",
-            )
+        interfaces = [] if self.check_interfaces is None else self.check_interfaces
 
-        if self.check_is_resettable_hook:
+        for interface in interfaces:
             self.assertIsInstance(
                 self.hook,
-                ResettableHook,
-                f"{self.hook_name} does not satisfy the ResettableHook interface",
+                interface,
+                f"{self.hook_name} does not satisfy the {interface.__name__} interface",
             )


### PR DESCRIPTION
Define a new interface for hooks that should have a 'clean-up' stage run
unconditionally before an event finishes executing. This is useful for
cases where a hook may introduce side effects on internal or global
state that should be rectified before we finish the event.

The two hooks seagrass.hooks.FileOpenHook and
seagrass.hooks.ProfilerHook now both implement this interface.

Closes #35.