### PR TITLE
Add the RuntimeAuditHook ABC

### DIFF
--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -93,9 +93,11 @@ these events is raised, along with the arguments passed to ``sys.audit``:
    posthook called: result=6
 
 Some of Seagrass's event hooks actually use runtime audit hooks internally. For
-instance, ``seagrass.hooks.FileOpenHook`` keeps track of all calls to the
-``open`` audit event that's built into Python in order to figure out what files
-are opened during an event.
+instance, :py:class:`seagrass.hooks.FileOpenHook`` keeps track of all calls to
+the ``open`` audit event that's built into Python in order to figure out what
+files are opened during a Seagrass event. Additionally, you can inherit from the
+:py:class:`seagrass.hooks.RuntimeAuditHook` abstract base class to create a hook
+whose body is executed as a runtime audit hook.
 
 .. _PEP 578: https://www.python.org/dev/peps/pep-0578/
 .. _Bypassing Python3.8 Audit Hooks: https://daddycocoaman.dev/posts/bypassing-python38-audit-hooks-part-1/

--- a/seagrass/hooks/__init__.py
+++ b/seagrass/hooks/__init__.py
@@ -2,8 +2,9 @@
 from .counter_hook import CounterHook
 from .file_open_hook import FileOpenHook
 from .logging_hook import LoggingHook
-from .stack_trace_hook import StackTraceHook
 from .profiler_hook import ProfilerHook
+from .runtime_audit_hook import RuntimeAuditHook
+from .stack_trace_hook import StackTraceHook
 from .timer_hook import TimerHook
 
 __all__ = [
@@ -12,5 +13,6 @@ __all__ = [
     "LoggingHook",
     "ProfilerHook",
     "StackTraceHook",
+    "RuntimeAuditHook",
     "TimerHook",
 ]

--- a/seagrass/hooks/runtime_audit_hook.py
+++ b/seagrass/hooks/runtime_audit_hook.py
@@ -1,0 +1,122 @@
+import sys
+import typing as t
+from abc import ABCMeta, abstractmethod
+from contextvars import ContextVar, Token
+from functools import wraps
+
+# Type variable used to represent value returned from a function
+R = t.TypeVar("R")
+
+
+class RuntimeAuditHook(metaclass=ABCMeta):
+    """Abstract base class that serves as a template for hooks whose body should be run as Python
+    runtime audit hooks, in accordance with `PEP 578`_.
+
+    **Examples:** in the code below, ``RuntimeEventCounterHook`` is a class derived from the
+    ``RuntimeAuditHook`` base class that prints every time a runtime audit event is triggered.
+
+    .. testsetup:: runtime-audit-hook-example
+
+        from seagrass.auditor import Auditor
+        auditor = Auditor()
+
+    .. doctest:: runtime-audit-hook-example
+
+        >>> import sys
+
+        >>> from seagrass.hooks import RuntimeAuditHook
+
+        >>> class RuntimeEventCounterHook(RuntimeAuditHook):
+        ...     def __init__(self):
+        ...         super().__init__()
+        ...
+        ...     def sys_hook(self, event, args):
+        ...         print(f"Encountered {event=!r} with {args=}")
+        ...
+
+        >>> hook = RuntimeEventCounterHook()
+
+        >>> @auditor.audit("my_event", hooks=[hook])
+        ... def my_event(*args):
+        ...     sys.audit("sys.my_event", *args)
+
+        >>> with auditor.start_auditing():
+        ...     my_event(42, "hello, world")
+        Encountered event='sys.my_event' with args=(42, 'hello, world')
+
+    .. _PEP 578: https://www.python.org/dev/peps/pep-0578/
+    """
+
+    # A ContextVar that stores the latest event that's being executed
+    _current_event_ctx: ContextVar[t.Optional[str]]
+
+    # We keep _is_active and _current_event as hidden members of the class so that they appear as
+    # read-only properties to child classes of RuntimeAuditHook.
+    _is_active: bool
+    _current_event: t.Optional[str]
+
+    @abstractmethod
+    def sys_hook(self, event: str, args: t.Any) -> None:
+        """The runtime auditing hook that gets executed every time sys.audit() is called.
+        This must be defined in child classes of RuntimeAuditHook."""
+
+    @property
+    def is_active(self) -> bool:
+        """Return whether or not the hook is currently active (i.e., whether a Seagrass event that
+        uses the hook is currently executing.)"""
+        return self._is_active
+
+    @property
+    def current_event(self) -> t.Optional[str]:
+        """Returns the current Seagrass event being executed that's hooked by this function. If no
+        events using this hook are being executed, ``current_event`` is ``None``."""
+        return self._current_event
+
+    def _update_properties(self) -> None:
+        """Update the ``current_event`` and ``is_active`` properties."""
+        self._current_event = self._current_event_ctx.get()
+        self._is_active = self.current_event is not None
+
+    def _update_decorator(func: t.Callable[..., R]) -> t.Callable[..., R]:  # type: ignore[misc]
+        # NOTE: mypy will flag this as erroneous because it is a non-static method that doesn't
+        # include the argument 'self'
+        # Ref: https://github.com/python/mypy/issues/7778
+        """Function decorator that causes functions to reset the current_event and is_active
+        properties every time it gets called."""
+
+        @wraps(func)
+        def wrapper(self, *args, **kwargs):
+            try:
+                return func(self, *args, **kwargs)
+            finally:
+                self._update_properties()
+
+        return wrapper
+
+    def __init__(self) -> None:
+        self._current_event_ctx = ContextVar("current_event", default=None)
+        self._update_properties()
+
+        # Add the runtime audit hook after initializing the properties since the hook will in most
+        # cases use some of the properties of the RuntimeAuditHook.
+        sys.addaudithook(self._sys_hook)
+
+    def _sys_hook(self, event: str, args: t.Any) -> None:
+        """A wrapper around the sys_hook abstract method that first checks whether the hook
+        is currently active before it executes anything. This is the function that actually
+        gets added with sys.addaudithook, not sys_hook."""
+        if self.is_active:
+            self.sys_hook(event, args)
+
+    @_update_decorator
+    def prehook(
+        self, event: str, args: t.Tuple[t.Any, ...], kwargs: t.Dict[str, t.Any]
+    ) -> Token:
+        return self._current_event_ctx.set(event)
+
+    def posthook(self, event: str, result: t.Any, context: Token) -> None:
+        pass
+
+    @_update_decorator
+    def cleanup(self, event: str, context: Token) -> None:
+        self._current_event_ctx.reset(context)

--- a/test/base/test_cleanup_hook.py
+++ b/test/base/test_cleanup_hook.py
@@ -56,7 +56,6 @@ class CleanupHookTestCase(SeagrassTestCaseMixin, unittest.TestCase):
 
     def setUp(self):
         super().setUp()
-        print(self.auditor)
         self.hook_a = self._HookA()
         self.hook_b = self._HookB()
         self.hook_c = self._HookC()

--- a/test/hooks/test_runtime_audit_hook.py
+++ b/test/hooks/test_runtime_audit_hook.py
@@ -1,0 +1,79 @@
+# Tests for the RuntimeAuditHook abstract base class.
+
+import tempfile
+import unittest
+from seagrass.base import CleanupHook
+from seagrass.hooks import RuntimeAuditHook
+from test.utils import HookTestCaseMixin
+
+
+class RuntimeHookTestCaseMixin(HookTestCaseMixin):
+    check_interfaces = (CleanupHook,)
+
+
+class FileOpenRuntimeAuditTestCase(HookTestCaseMixin, unittest.TestCase):
+    """Build an auditing hook for tracking file opens out of RuntimeAuditHook, similar to
+    FileOpenHook."""
+
+    class _Hook(RuntimeAuditHook):
+        def __init__(self):
+            super().__init__()
+            self.total_file_opens = 0
+
+        def sys_hook(self, event_name, args):
+            if event_name == "open":
+                self.total_file_opens += 1
+                self.opened_filename = args[0]
+                self.opened_mode = args[1]
+
+    hook_gen = _Hook
+
+    def test_hook_function(self):
+        @self.auditor.audit("test.say_hello", hooks=[self.hook])
+        def say_hello(filename) -> str:
+            with open(filename, "w") as f:
+                f.write("Hello!\n")
+
+            with open(filename, "r") as f:
+                return f.read()
+
+        with tempfile.NamedTemporaryFile() as f:
+            # Even though we're using sys.audit hooks, calls to say_hello should not
+            # trigger the audit hook unless we're in an auditing context.
+            say_hello(f.name)
+            with self.auditor.start_auditing():
+                say_hello(f.name)
+            say_hello(f.name)
+
+            self.assertEqual(self.hook.total_file_opens, 2)
+            self.assertEqual(self.hook.opened_filename, f.name)
+            self.assertEqual(self.hook.opened_mode, "r")
+
+    def test_hook_works_if_an_exception_is_raised(self):
+        # In the case where an exception is raised in the body of the function, the hook
+        # should still work correctly.
+        @self.auditor.audit("test.erroneous_func", hooks=[self.hook])
+        def erroneous_func(filename):
+            with open(filename, "w") as f:
+                f.write("Hello!\n")
+
+            # Artificially raise an error at this point
+            assert False
+
+        def try_erroneous_func(filename):
+            try:
+                return erroneous_func(filename)
+            except:
+                pass
+
+        with tempfile.NamedTemporaryFile() as f:
+            try_erroneous_func(f.name)
+            with self.auditor.start_auditing():
+                try_erroneous_func(f.name)
+            try_erroneous_func(f.name)
+
+            self.assertEqual(self.hook.total_file_opens, 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/utils.py
+++ b/test/utils.py
@@ -1,6 +1,7 @@
 # Testing utilities and base classes for testing Seagrass
 
 import logging
+import logging.config
 import typing as t
 from io import StringIO
 from seagrass import Auditor
@@ -14,17 +15,35 @@ class SeagrassTestCaseMixin:
     auditor: Auditor
 
     def setUp(self) -> None:
-        # Set up an auditor with a basic logging configuration
+        # Set up logging configuration
         self.logging_output = StringIO()
-        fh = logging.StreamHandler(self.logging_output)
-        fh.setLevel(logging.DEBUG)
 
-        formatter = logging.Formatter("(%(levelname)s) %(message)s")
-        fh.setFormatter(formatter)
+        logging.config.dictConfig({
+            "version": 1,
+            "disable_existing_loggers": True,
+            "formatters": {
+                "standard": {
+                    "format": "(%(levelname)s) %(message)s",
+                },
+            },
+            "handlers": {
+                "default": {
+                    "level": "DEBUG",
+                    "formatter": "standard",
+                    "class": "logging.StreamHandler",
+                    "stream": self.logging_output,
+                },
+            },
+            "loggers": {
+                "test.seagrass": {
+                    "handlers": ["default"],
+                    "level": "DEBUG",
+                    "propagate": False,
+                },
+            }
+        })
 
         self.logger = logging.getLogger("test.seagrass")
-        self.logger.setLevel(logging.DEBUG)
-        self.logger.addHandler(fh)
 
         # Create a new auditor instance with the logger we just
         # set up

--- a/tox.ini
+++ b/tox.ini
@@ -50,7 +50,7 @@ addopts = -rsf
 
 [flake8]
 max-line-length = 120
-ignore = F811
+ignore = E722,F811
 exclude =
     # From .gitignore
     dist,


### PR DESCRIPTION
Create a new abstract base class (ABC), `RuntimeAuditHook`, that allows users to create hooks that are executed as *Python runtime* auditing hooks rather than *Seagrass* auditing hooks (per [PEP 578](https://www.python.org/dev/peps/pep-0578/)).

Closes #7.