### PR TITLE
Fix issue where ProfilerHook would be prematurely disabled.

### DIFF
--- a/test/hooks/test_profiler_hook.py
+++ b/test/hooks/test_profiler_hook.py
@@ -2,7 +2,7 @@
 
 import time
 import unittest
-from test.utils import HookTestCaseMixin
+from test.utils import HookTestCaseMixin, req_python_version
 from seagrass.base import LogResultsHook, ResettableHook, CleanupHook
 from seagrass.hooks import ProfilerHook
 
@@ -15,13 +15,9 @@ class ProfilerHookTestCase(HookTestCaseMixin, unittest.TestCase):
     def hook_gen():
         return ProfilerHook(sort_keys="cumtime", restrictions=0.1)
 
+    # Test only works for Python >= 3.9 due to the use of StatsProfile
+    @req_python_version(min=(3, 9))
     def test_hook_function(self):
-        # Test only works for Python >= 3.9 due to the use of StatsProfile
-        try:
-            from pstats import StatsProfile  # noqa: F401
-        except ImportError:
-            self.skipTest("Test disabled for Python < 3.9")
-
         # Note: could just as easily use auditor.audit("test.sleep", time.sleep, ...)
         # here but the name of time.sleep is slightly mangled in the resulting
         # StatsProfile that we generate, which complicates testing.
@@ -51,3 +47,37 @@ class ProfilerHookTestCase(HookTestCaseMixin, unittest.TestCase):
         ausleep_profile = stats_profile.func_profiles["ausleep"]
         self.assertEqual(ausleep_profile.ncalls, "1")
         self.assertAlmostEqual(ausleep_profile.cumtime, 0.01, delta=0.005)
+
+    # Test only works for Python >= 3.9 due to the use of StatsProfile
+    @req_python_version(min=(3, 9))
+    def test_hook_nested_functions(self):
+        # Ensure that the profiler collects information about nested events
+        @self.auditor.audit("test.foo", hooks=[self.hook])
+        def foo(*args):
+            time.sleep(*args)
+
+        @self.auditor.audit("test.bar", hooks=[self.hook])
+        def bar(*args):
+            foo(0)
+            foo(*args)
+
+        @self.auditor.audit("test.baz", hooks=[self.hook])
+        def baz(*args):
+            bar(0)
+            bar(*args)
+
+        with self.auditor.start_auditing():
+            baz(0.05)
+
+        stats_profile = self.hook.get_stats().get_stats_profile()
+        foo_profile = stats_profile.func_profiles["foo"]
+        bar_profile = stats_profile.func_profiles["bar"]
+        baz_profile = stats_profile.func_profiles["baz"]
+
+        self.assertTrue(foo_profile.cumtime >= 0.05)
+        self.assertTrue(bar_profile.cumtime >= 0.05)
+        self.assertTrue(baz_profile.cumtime >= 0.05)
+
+        self.assertEqual(foo_profile.ncalls, "4")
+        self.assertEqual(bar_profile.ncalls, "2")
+        self.assertEqual(baz_profile.ncalls, "1")


### PR DESCRIPTION
Fix a bug where ProfilerHook is disabled every time cleanup() gets
called, which causes us to miss profiling information in the outer event
of a pair of nested events. Previously, profiling would be disabled once
we exited the inner event, which means that if there was any code
between the end of the inner event and the end of the outer event, the
profiler would completely miss it.