### PR TITLE
Add a global Auditor instance

### DIFF
--- a/seagrass/__init__.py
+++ b/seagrass/__init__.py
@@ -1,7 +1,36 @@
 # flake8: noqa: F401
+import typing as t
 from .auditor import Auditor, get_audit_logger, DEFAULT_LOGGER_NAME
+
+# "Global auditor" that can be used to audit events without having to create an
+# auditor first.
+__GLOBAL_AUDITOR: t.Final[Auditor] = Auditor()
+
+def global_auditor() -> Auditor:
+    return __GLOBAL_AUDITOR
+
+# Export the external API of the global Auditor instance from the module
+audit = global_auditor().audit
+create_event = global_auditor().create_event
+raise_event = global_auditor().raise_event
+toggle_event = global_auditor().toggle_event
+toggle_auditing = global_auditor().toggle_auditing
+start_auditing = global_auditor().start_auditing
+add_hooks = global_auditor().add_hooks
+reset_hooks = global_auditor().reset_hooks
+log_results = global_auditor().log_results
 
 __all__ = [
     "Auditor",
     "get_audit_logger",
+    "global_auditor",
+    "audit",
+    "create_event",
+    "raise_event",
+    "toggle_event",
+    "toggle_auditing",
+    "start_auditing",
+    "add_hooks",
+    "reset_hooks",
+    "log_results",
 ]

--- a/seagrass/auditor.py
+++ b/seagrass/auditor.py
@@ -12,7 +12,9 @@ DEFAULT_LOGGER_NAME: str = "seagrass"
 
 # A context variable that keeps track of the auditor's logger for the
 # current auditing context.
-_current_audit_logger: ContextVar[t.Optional[logging.Logger]] = ContextVar("audit_logger", default=None)
+_current_audit_logger: ContextVar[t.Optional[logging.Logger]] = ContextVar(
+    "audit_logger", default=None
+)
 
 # A type variable used to represent a function that can take
 # arbitrary/unknown inputs and returns an arbitrary/unknown type
@@ -36,7 +38,9 @@ class Auditor:
     hooks: t.Set[ProtoHook]
     __enabled: bool = False
 
-    def __init__(self, logger: t.Union[str, logging.Logger] = DEFAULT_LOGGER_NAME) -> None:
+    def __init__(
+        self, logger: t.Union[str, logging.Logger] = DEFAULT_LOGGER_NAME
+    ) -> None:
         """Create a new Auditor instance.
 
         :param Union[str,logging.Logger] logger: The logger that this auditor should use. When set
@@ -52,7 +56,7 @@ class Auditor:
         self.hooks = set()
 
     @property
-    def is_enabled(self) -> bool:
+    def enabled(self) -> bool:
         """Return whether or not the auditor is enabled.
 
         :type: bool
@@ -209,7 +213,7 @@ class Auditor:
 
         @functools.wraps(func)
         def wrapper(*args, **kwargs):
-            if not self.is_enabled:
+            if not self.enabled:
                 return new_event.func(*args, **kwargs)
             else:
                 return new_event(*args, **kwargs)

--- a/seagrass/auditor.py
+++ b/seagrass/auditor.py
@@ -2,6 +2,7 @@ import functools
 import logging
 import typing as t
 from contextlib import contextmanager
+from contextvars import ContextVar
 from seagrass.base import LogResultsHook, ProtoHook, ResettableHook
 from seagrass.errors import EventNotFoundError
 from seagrass.events import Event
@@ -9,9 +10,9 @@ from seagrass.events import Event
 # The name of the default logger used by Seagrass
 DEFAULT_LOGGER_NAME: str = "seagrass"
 
-# Global variable that keeps track of the auditor's logger for the
+# A context variable that keeps track of the auditor's logger for the
 # current auditing context.
-_audit_logger_stack: t.List[logging.Logger] = []
+_current_audit_logger: ContextVar[t.Optional[logging.Logger]] = ContextVar("audit_logger", default=None)
 
 # A type variable used to represent a function that can take
 # arbitrary/unknown inputs and returns an arbitrary/unknown type
@@ -97,12 +98,12 @@ class Auditor:
             auditing context.
         """
         try:
+            token = _current_audit_logger.set(self.logger)
             self.toggle_auditing(True)
-            _audit_logger_stack.append(self.logger)
             yield None
         finally:
             self.toggle_auditing(False)
-            _audit_logger_stack.pop()
+            _current_audit_logger.reset(token)
 
             if log_results:
                 self.log_results()
@@ -346,7 +347,4 @@ def get_audit_logger() -> t.Optional[logging.Logger]:
     :return: the logger for the most recent auditing context (or ``None``).
     :rtype: Optional[logging.Logger]
     """
-    if len(_audit_logger_stack) == 0:
-        return None
-    else:
-        return _audit_logger_stack[-1]
+    return _current_audit_logger.get()

--- a/test/test_auditor.py
+++ b/test/test_auditor.py
@@ -1,6 +1,7 @@
 # Tests for Auditor creation and basic functionality
 
 import logging
+import seagrass
 import unittest
 from io import StringIO
 from seagrass import Auditor, get_audit_logger
@@ -162,6 +163,23 @@ class SimpleAuditorFunctionsTestCase(SeagrassTestCaseMixin, unittest.TestCase):
         # Now that we're back outside of an auditing context, get_audit_logger()
         # should once again return None.
         self.assertEqual(get_audit_logger(), None)
+
+
+class GlobalAuditorTestCase(unittest.TestCase):
+    """Tests for using the global auditor instance."""
+
+    def test_use_counter_hook_with_global_auditor(self):
+        hook = seagrass.hooks.CounterHook()
+
+        @seagrass.audit("test.foo", hooks=[hook])
+        def foo():
+            pass
+
+        with seagrass.start_auditing():
+            for _ in range(10):
+                foo()
+
+        self.assertEqual(hook.event_counter["test.foo"], 10)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Add `__GLOBAL_AUDITOR` that users can use to audit events instead of having to create their own auditor.

Closes #41.