### PR TITLE
Add new attributes to the ProtoHook protocol

### DIFF
--- a/docs/source/tips_and_tricks.rst
+++ b/docs/source/tips_and_tricks.rst
@@ -39,9 +39,11 @@ with the new one:
 
    >>> from seagrass import Auditor
 
+   >>> from seagrass.base import ProtoHook
+
    >>> auditor = Auditor()
 
-   >>> class PrintEventHook:
+   >>> class PrintEventHook(ProtoHook[None]):
    ...     def prehook(self, event, args, kwargs):
    ...         print(f"{self.__class__.__name__}: {event} triggered")
    ...     def posthook(self, event, result, context):

--- a/seagrass/events.py
+++ b/seagrass/events.py
@@ -1,7 +1,7 @@
 import sys
 import typing as t
 from enum import Enum, auto
-from seagrass.base import ProtoHook, CleanupHook, prehook_priority, posthook_priority
+from seagrass.base import ProtoHook, CleanupHook
 from seagrass.errors import PosthookError
 
 # A type variable used to represent the function wrapped by an Event.
@@ -110,11 +110,11 @@ class Event:
         # - Prehooks are ordered by ascending priority, then ascending list position
         # - Posthooks are ordered by descending priority, then descending list position
         self.__prehook_execution_order = sorted(
-            range(len(self.hooks)), key=lambda i: (prehook_priority(self.hooks[i]), i)
+            range(len(self.hooks)), key=lambda i: (self.hooks[i].prehook_priority, i)
         )
         self.__posthook_execution_order = sorted(
             range(len(self.hooks)),
-            key=lambda i: (-posthook_priority(self.hooks[i]), -i),
+            key=lambda i: (-self.hooks[i].posthook_priority, -i)
         )
 
     def __call__(self, *args, **kwargs) -> t.Any:

--- a/seagrass/events.py
+++ b/seagrass/events.py
@@ -1,6 +1,5 @@
 import sys
 import typing as t
-from enum import Enum, auto
 from seagrass.base import ProtoHook, CleanupHook
 from seagrass.errors import PosthookError
 
@@ -8,12 +7,14 @@ from seagrass.errors import PosthookError
 F = t.Callable[..., t.Any]
 
 
-class _HookContext(Enum):
-    # Enum class used to represent cases where we don't have the context for a posthook
-    MISSING = auto()
+class __MissingHookContext:
+    __slots__: t.List[str] = []
 
     def __repr__(self):
-        return f"<{self.__class__.__name__}.{self.name}>"
+        return "<Event.MISSING_CONTEXT>"
+
+
+MISSING_CONTEXT: t.Final[__MissingHookContext] = __MissingHookContext()
 
 
 class Event:
@@ -113,8 +114,7 @@ class Event:
             range(len(self.hooks)), key=lambda i: (self.hooks[i].prehook_priority, i)
         )
         self.__posthook_execution_order = sorted(
-            range(len(self.hooks)),
-            key=lambda i: (-self.hooks[i].posthook_priority, -i)
+            range(len(self.hooks)), key=lambda i: (-self.hooks[i].posthook_priority, -i)
         )
 
     def __call__(self, *args, **kwargs) -> t.Any:
@@ -140,8 +140,9 @@ class Event:
             prehook_contexts = {}
             for hook_num in self.__prehook_execution_order:
                 hook = self.hooks[hook_num]
-                context = hook.prehook(self.name, args, kwargs)
-                prehook_contexts[hook_num] = context
+                if hook.enabled:
+                    context = hook.prehook(self.name, args, kwargs)
+                    prehook_contexts[hook_num] = context
 
             result = self.func(*args, **kwargs)
 
@@ -157,8 +158,8 @@ class Event:
                 # In some cases (e.g., if a prehook raises an Exception), a context may
                 # not exist for a given hook. We only execute the posthook and cleanup
                 # if a context exists.
-                context = prehook_contexts.get(hook_num, _HookContext.MISSING)
-                if context != _HookContext.MISSING:
+                context = prehook_contexts.get(hook_num, MISSING_CONTEXT)
+                if context != MISSING_CONTEXT:
                     hook = self.hooks[hook_num]
                     if not exception_raised:
                         try:

--- a/seagrass/hooks/counter_hook.py
+++ b/seagrass/hooks/counter_hook.py
@@ -47,10 +47,6 @@ class CounterHook(ProtoHook[None]):
     ) -> None:
         self.event_counter[event_name] += 1
 
-    def posthook(self, event_name: str, result: t.Any, context: None) -> None:
-        # Posthook does nothing
-        pass
-
     def reset(self) -> None:
         self.event_counter.clear()
 

--- a/seagrass/hooks/counter_hook.py
+++ b/seagrass/hooks/counter_hook.py
@@ -1,9 +1,10 @@
 import logging
 import typing as t
 from collections import Counter
+from seagrass.base import ProtoHook
 
 
-class CounterHook:
+class CounterHook(ProtoHook[None]):
     """A Seagrass hook that counts the number of times an event occurs.
 
     **Examples:**

--- a/seagrass/hooks/logging_hook.py
+++ b/seagrass/hooks/logging_hook.py
@@ -1,13 +1,14 @@
 import logging
 import typing as t
 from seagrass import get_audit_logger
+from seagrass.base import ProtoHook
 
 log_input_t = str
 prehook_msg_t = t.Callable[[str, t.Tuple[t.Any, ...], t.Dict[str, t.Any]], log_input_t]
 posthook_msg_t = t.Callable[[str, t.Any], log_input_t]
 
 
-class LoggingHook:
+class LoggingHook(ProtoHook[None]):
     """A hook that emits a new log whenever it gets called."""
 
     loglevel: int

--- a/seagrass/hooks/runtime_audit_hook.py
+++ b/seagrass/hooks/runtime_audit_hook.py
@@ -4,12 +4,13 @@ from abc import ABCMeta, abstractmethod
 from contextlib import contextmanager
 from functools import wraps
 from seagrass import get_audit_logger
+from seagrass.base import ProtoHook
 
 # Type variable used to represent value returned from a function
 R = t.TypeVar("R")
 
 
-class RuntimeAuditHook(metaclass=ABCMeta):
+class RuntimeAuditHook(ProtoHook[t.Optional[str]], metaclass=ABCMeta):
     """Abstract base class that serves as a template for hooks whose body should be run as Python
     runtime audit hooks, in accordance with `PEP 578`_.
 

--- a/seagrass/hooks/stack_trace_hook.py
+++ b/seagrass/hooks/stack_trace_hook.py
@@ -50,9 +50,5 @@ class StackTraceHook(ProtoHook[None]):
             # See note in https://docs.python.org/3/library/inspect.html#the-interpreter-stack
             del current_stack
 
-    def posthook(self, event: str, result: t.Any, context: None) -> None:
-        # Posthook does nothing
-        pass
-
     def reset(self) -> None:
         self.stack_trace_counter.clear()

--- a/seagrass/hooks/stack_trace_hook.py
+++ b/seagrass/hooks/stack_trace_hook.py
@@ -1,6 +1,7 @@
 import inspect
 import typing as t
 from collections import Counter, defaultdict
+from seagrass.base import ProtoHook
 
 
 class TracedFrame(t.NamedTuple):
@@ -21,7 +22,7 @@ class TracedFrame(t.NamedTuple):
         return f"{self.filename}#{self.lineno}"
 
 
-class StackTraceHook:
+class StackTraceHook(ProtoHook[None]):
     """An audit hook that captures the stack trace of where events are raised
     and collects statistics about caller locations."""
 

--- a/seagrass/hooks/timer_hook.py
+++ b/seagrass/hooks/timer_hook.py
@@ -4,9 +4,10 @@ import logging
 import time
 import typing as t
 from collections import defaultdict
+from seagrass.base import ProtoHook
 
 
-class TimerHook:
+class TimerHook(ProtoHook[float]):
 
     # Relatively high prehook/posthook priority so that TimerHook gets
     # called soon before and after a wrapped function.

--- a/test/base/test_cleanup_hook.py
+++ b/test/base/test_cleanup_hook.py
@@ -1,7 +1,7 @@
 # Tests for hook satisfying the CleanupHook interface.
 
 import unittest
-from seagrass.base import CleanupHook, ResettableHook
+from seagrass.base import ProtoHook, CleanupHook, ResettableHook
 from seagrass.errors import PosthookError
 from test.utils import SeagrassTestCaseMixin
 
@@ -10,7 +10,7 @@ class CleanupHookTestCase(SeagrassTestCaseMixin, unittest.TestCase):
     """Tests to check that the cleanup stage of hooks that satisfy the CleanupHook interface
     is unconditionally executed."""
 
-    class _BaseTestHook:
+    class _BaseTestHook(ProtoHook[None]):
         def __init__(self):
             self.reset()
 

--- a/test/test_auditor.py
+++ b/test/test_auditor.py
@@ -5,6 +5,7 @@ import seagrass
 import unittest
 from io import StringIO
 from seagrass import Auditor, get_audit_logger
+from seagrass.base import ProtoHook
 from seagrass.errors import EventNotFoundError
 from test.utils import SeagrassTestCaseMixin
 
@@ -86,7 +87,7 @@ class SimpleAuditorFunctionsTestCase(SeagrassTestCaseMixin, unittest.TestCase):
         with self.assertRaises(EventNotFoundError):
             self.auditor.raise_event("test.signal", 1, 2, name="Alice")
 
-        class TestHook:
+        class TestHook(ProtoHook):
             def __init__(self):
                 self.last_prehook_args = self.last_posthook_args = None
 
@@ -122,7 +123,7 @@ class SimpleAuditorFunctionsTestCase(SeagrassTestCaseMixin, unittest.TestCase):
                 self.auditor.raise_event("my_sum.cumsum", total)
                 total += arg
 
-        class MySumHook:
+        class MySumHook(ProtoHook[None]):
             def __init__(self):
                 self.cumsums = []
 

--- a/test/test_base.py
+++ b/test/test_base.py
@@ -11,7 +11,7 @@ class CustomHookImplementationTestCase(unittest.TestCase):
         self.CheckableProtoHook = t.runtime_checkable(base.ProtoHook)
 
     def test_get_prehook_and_posthook_priority(self):
-        class MyHook:
+        class MyHook(base.ProtoHook[None]):
             prehook_priority: int = 7
 
             def prehook(self, *args):
@@ -26,17 +26,8 @@ class CustomHookImplementationTestCase(unittest.TestCase):
             self.CheckableProtoHook,
             f"{hook.__class__.__name__} does not satisfy the hooking protocol",
         )
-        self.assertEqual(base.prehook_priority(hook), 7)
-        self.assertEqual(base.posthook_priority(hook), base.DEFAULT_POSTHOOK_PRIORITY)
-
-        # The prehook_priority and posthook_priority are both required to be integers
-        hook.prehook_priority = "Alice"
-        with self.assertRaises(TypeError):
-            base.prehook_priority(hook)
-
-        hook.posthook_priority = None
-        with self.assertRaises(TypeError):
-            base.posthook_priority(hook)
+        self.assertEqual(hook.prehook_priority, 7)
+        self.assertEqual(hook.posthook_priority, base.DEFAULT_POSTHOOK_PRIORITY)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Add `enabled`, `prehook_priority`, and `posthook_priority` to the `ProtoHook` protocol. In addition, I've made all of the hooks in `seagrass.hooks`, as well as hooks used by the tests and shown in the documentation, inherit from `ProtoHook`. While this isn't strictly necessary, going forwards, it'll be easier to have hooks inherit from `ProtoHook` so that new hooks can be developed quicker and so that we can define a set of baseline behaviors for hooks.

Other changes:

- I've configured `Event` to check for the `enabled` property in hooks. If it's set to `False`, then the prehook (and by extension, posthook and cleanup) doesn't get executed.
- `ProfilerHook` no longer uses a context variable to store whether or not it's active (see #47 -- the reasoning is the same here).

Closes #20. Closes #39.