### PR TITLE
Improvements to exported _GLOBAL_AUDITOR attributes

### DIFF
--- a/seagrass/__init__.py
+++ b/seagrass/__init__.py
@@ -73,6 +73,7 @@ __EXPORTED_AUDITOR_FUNCTIONS = set(
         "add_hooks",
         "reset_hooks",
         "log_results",
+        "logger",
     ]
 )
 

--- a/seagrass/__init__.py
+++ b/seagrass/__init__.py
@@ -30,15 +30,17 @@ _EXPORTED_AUDITOR_ATTRIBUTES = [
 ]
 
 
+def _global_auditor_attrs():
+    # Collect the exported attributes of the current global auditor into a dictionary
+    auditor = global_auditor()
+    return dict((attr, getattr(auditor, attr)) for attr in _EXPORTED_AUDITOR_ATTRIBUTES)
+
+
 # Create context variables to cache attributes that we've already looked up on the auditor. This makes
 # lookups on module attributes a bit faster.
-_GLOBAL_AUDITOR_ATTRS: t.Dict[str, ContextVar[t.Any]] = {}
-
-for attr in _EXPORTED_AUDITOR_ATTRIBUTES:
-    attr_var = ContextVar(
-        f"_GLOBAL_AUDITOR.{attr}", default=getattr(_GLOBAL_AUDITOR.get(), attr)
-    )
-    _GLOBAL_AUDITOR_ATTRS[attr] = attr_var
+_GLOBAL_AUDITOR_ATTRS: ContextVar[t.Dict[str, t.Any]] = ContextVar(
+    "_GLOBAL_AUDITOR_ATTRS", default=_global_auditor_attrs()
+)
 
 
 class create_global_auditor(t.ContextManager[Auditor]):
@@ -81,15 +83,12 @@ class create_global_auditor(t.ContextManager[Auditor]):
 
     def __enter__(self) -> Auditor:
         self.auditor_token = _GLOBAL_AUDITOR.set(self.new_auditor)
-        self.attr_tokens = {}
-        for (attr, var) in _GLOBAL_AUDITOR_ATTRS.items():
-            self.attr_tokens[attr] = var.set(getattr(self.new_auditor, attr))
+        self.attrs_token = _GLOBAL_AUDITOR_ATTRS.set(_global_auditor_attrs())
         return self.new_auditor
 
     def __exit__(self, *args) -> None:
         _GLOBAL_AUDITOR.reset(self.auditor_token)
-        for (attr, token) in self.attr_tokens.items():
-            _GLOBAL_AUDITOR_ATTRS[attr].reset(token)
+        _GLOBAL_AUDITOR_ATTRS.reset(self.attrs_token)
 
 
 __all__ = [
@@ -104,7 +103,7 @@ __all__ += _EXPORTED_AUDITOR_ATTRIBUTES
 
 def __getattr__(attr: str) -> t.Any:
     if (auditor_attr := _GLOBAL_AUDITOR_ATTRS.get(attr)) is not None:
-        return auditor_attr.get()
+        return auditor_attr
     else:
         raise AttributeError(f"module {__name__!r} has no attribute {attr!r}")
 

--- a/seagrass/__init__.py
+++ b/seagrass/__init__.py
@@ -6,13 +6,39 @@ from contextvars import ContextVar
 # "Global auditor" that can be used to audit events without having to create an
 # auditor first.
 _GLOBAL_AUDITOR: ContextVar[Auditor] = ContextVar(
-    "__GLOBAL_SEAGRASS_AUDITOR", default=Auditor()
+    "_GLOBAL_SEAGRASS_AUDITOR", default=Auditor()
 )
 
 
 def global_auditor() -> Auditor:
     """Return the global Seagrass auditor."""
     return _GLOBAL_AUDITOR.get()
+
+
+# Export parts of the external API of the global Auditor instance from the module
+_EXPORTED_AUDITOR_ATTRIBUTES = [
+    "audit",
+    "create_event",
+    "raise_event",
+    "toggle_event",
+    "toggle_auditing",
+    "start_auditing",
+    "add_hooks",
+    "reset_hooks",
+    "log_results",
+    "logger",
+]
+
+
+# Create context variables to cache attributes that we've already looked up on the auditor. This makes
+# lookups on module attributes a bit faster.
+_GLOBAL_AUDITOR_ATTRS: t.Dict[str, ContextVar[t.Any]] = {}
+
+for attr in _EXPORTED_AUDITOR_ATTRIBUTES:
+    attr_var = ContextVar(
+        f"_GLOBAL_AUDITOR.{attr}", default=getattr(_GLOBAL_AUDITOR.get(), attr)
+    )
+    _GLOBAL_AUDITOR_ATTRS[attr] = attr_var
 
 
 class create_global_auditor(t.ContextManager[Auditor]):
@@ -54,41 +80,34 @@ class create_global_auditor(t.ContextManager[Auditor]):
             self.new_auditor = auditor
 
     def __enter__(self) -> Auditor:
-        self.token = _GLOBAL_AUDITOR.set(self.new_auditor)
+        self.auditor_token = _GLOBAL_AUDITOR.set(self.new_auditor)
+        self.attr_tokens = {}
+        for (attr, var) in _GLOBAL_AUDITOR_ATTRS.items():
+            self.attr_tokens[attr] = var.set(getattr(self.new_auditor, attr))
         return self.new_auditor
 
     def __exit__(self, *args) -> None:
-        _GLOBAL_AUDITOR.reset(self.token)
-
-
-# Export the external API of the global Auditor instance from the module
-__EXPORTED_AUDITOR_FUNCTIONS = set(
-    [
-        "audit",
-        "create_event",
-        "raise_event",
-        "toggle_event",
-        "toggle_auditing",
-        "start_auditing",
-        "add_hooks",
-        "reset_hooks",
-        "log_results",
-        "logger",
-    ]
-)
-
-
-def __getattr__(attr: str) -> t.Any:
-    if attr in __EXPORTED_AUDITOR_FUNCTIONS:
-        return getattr(global_auditor(), attr)
-    else:
-        raise AttributeError(f"module {__name__!r} has no attribute {attr!r}")
+        _GLOBAL_AUDITOR.reset(self.auditor_token)
+        for (attr, token) in self.attr_tokens.items():
+            _GLOBAL_AUDITOR_ATTRS[attr].reset(token)
 
 
 __all__ = [
     "Auditor",
     "get_audit_logger",
     "global_auditor",
+    "create_global_auditor",
 ]
 
-__all__ += list(__EXPORTED_AUDITOR_FUNCTIONS)
+__all__ += _EXPORTED_AUDITOR_ATTRIBUTES
+
+
+def __getattr__(attr: str) -> t.Any:
+    if (auditor_attr := _GLOBAL_AUDITOR_ATTRS.get(attr)) is not None:
+        return auditor_attr.get()
+    else:
+        raise AttributeError(f"module {__name__!r} has no attribute {attr!r}")
+
+
+def __dir__() -> t.List[str]:
+    return __all__

--- a/test/test_auditor.py
+++ b/test/test_auditor.py
@@ -232,6 +232,8 @@ class GlobalAuditorTestCase(unittest.TestCase):
 
         with seagrass.create_global_auditor() as auditor:
             self.assertEqual(seagrass.global_auditor(), auditor)
+            self.assertEqual(seagrass.audit, auditor.audit)
+            self.assertEqual(seagrass.create_event, auditor.create_event)
 
             # Any events created inside of this context should be created with the new auditor
             @seagrass.audit("test.foo", hooks=[hook])
@@ -241,6 +243,8 @@ class GlobalAuditorTestCase(unittest.TestCase):
         # Outside of the context, the auditor should be set back to the original
         # global auditor.
         self.assertNotEqual(seagrass.global_auditor(), auditor)
+        self.assertNotEqual(seagrass.audit, auditor.audit)
+        self.assertNotEqual(seagrass.create_event, auditor.create_event)
 
         # Events created inside of the context should only be raised with the newly-created
         # auditor.
@@ -256,6 +260,11 @@ class GlobalAuditorTestCase(unittest.TestCase):
         auditor = Auditor()
         with seagrass.create_global_auditor(auditor):
             self.assertEqual(seagrass.global_auditor(), auditor)
+            self.assertEqual(seagrass.audit, auditor.audit)
+            self.assertEqual(seagrass.create_event, auditor.create_event)
+
+        self.assertNotEqual(seagrass.audit, auditor.audit)
+        self.assertNotEqual(seagrass.create_event, auditor.create_event)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
- Export the current `_GLOBAL_AUDITOR`'s logger from the `seagrass` module, so that it's now accessible as `seagrass.logger`.
- Improve the method used to look up attributes on the `_GLOBAL_AUDITOR` to be a bit faster than before.