### PR TITLE
Make it possible to auto-name Seagrass events.

### DIFF
--- a/seagrass/__init__.py
+++ b/seagrass/__init__.py
@@ -15,6 +15,39 @@ def global_auditor() -> Auditor:
     return _GLOBAL_AUDITOR.get()
 
 
+def auto(func: t.Callable) -> str:
+    """Automatically generate an event name for a function being audited.
+
+    **Examples:**
+
+        .. testsetup:: auto-doctests
+
+            from seagrass import Auditor
+            from seagrass._docs import configure_logging
+            configure_logging()
+            auditor = Auditor()
+
+        .. doctest:: auto-doctests
+
+            >>> from seagrass import auto
+
+            >>> from time import sleep
+
+            >>> event = auditor.audit(auto, sleep)
+
+            >>> event.__event_name__
+            'time.sleep'
+
+            >>> from pathlib import Path
+
+            >>> event = auditor.audit(auto, Path.home)
+
+            >>> event.__event_name__
+            'pathlib.Path.home'
+    """
+    return f"{func.__module__}.{func.__qualname__}"
+
+
 # Export parts of the external API of the global Auditor instance from the module
 _EXPORTED_AUDITOR_ATTRIBUTES = [
     "audit",
@@ -97,6 +130,7 @@ __all__ = [
     "get_audit_logger",
     "global_auditor",
     "create_global_auditor",
+    "auto",
 ]
 
 __all__ += _EXPORTED_AUDITOR_ATTRIBUTES

--- a/test/test_events.py
+++ b/test/test_events.py
@@ -1,5 +1,6 @@
 # Tests for raising Python audit events with sys.audit through Auditors
 
+import seagrass
 import sys
 import unittest
 import warnings
@@ -7,6 +8,15 @@ from collections import Counter, defaultdict
 from seagrass import auto
 from seagrass.hooks import CounterHook
 from test.utils import SeagrassTestCaseMixin
+
+with seagrass.create_global_auditor():
+
+    class ExampleClass:
+        # Test class used to check how functions are auto-named by Seagrass
+        @staticmethod
+        @seagrass.audit(auto)
+        def say_hello(name: str) -> str:
+            return f"Hello, {name}!"
 
 
 class EventsTestCase(SeagrassTestCaseMixin, unittest.TestCase):
@@ -176,6 +186,12 @@ class EventsTestCase(SeagrassTestCaseMixin, unittest.TestCase):
 
         auhome = self.auditor.audit(auto, Path.home)
         self.assertEqual(auhome.__event_name__, "pathlib.Path.home")
+
+        # Check the name of the audited function from the ExampleClass class at
+        # the top of the file.
+        self.assertEqual(
+            ExampleClass.say_hello.__event_name__, f"{__name__}.ExampleClass.say_hello"
+        )
 
 
 if __name__ == "__main__":

--- a/test/test_events.py
+++ b/test/test_events.py
@@ -4,15 +4,13 @@ import sys
 import unittest
 import warnings
 from collections import Counter, defaultdict
-from seagrass import Auditor
+from seagrass import auto
 from seagrass.hooks import CounterHook
+from test.utils import SeagrassTestCaseMixin
 
 
-class EventsTestCase(unittest.TestCase):
+class EventsTestCase(SeagrassTestCaseMixin, unittest.TestCase):
     """Tests for events created by Seagrass."""
-
-    def setUp(self):
-        self.auditor = Auditor()
 
     def test_wrap_class_property(self):
         # Override a class property to call a hook whenever it's accessed
@@ -172,6 +170,12 @@ class EventsTestCase(unittest.TestCase):
         run_fns(test_args, test_kwargs)
         self.assertEqual(set(events_counter), set())
         self.assertEqual(set(args_dict), set())
+
+    def test_auto_name_event(self):
+        from pathlib import Path
+
+        auhome = self.auditor.audit(auto, Path.home)
+        self.assertEqual(auhome.__event_name__, "pathlib.Path.home")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Allow Seagrass to accept a function for the event name used by
Auditor.audit, which takes a function and generates an event name from
it. Add an 'auto' function to seagrass that can be used to automatically
generate event names for functions, e.g.

    import seagrass

    @seagrass.audit(seagrass.auto)
    def foo(*args, **kwargs):
        ...

The auto-generated name will be based on the path to the audited
function.

Closes #50.