### PR TITLE
Add 'exception' as an argument to 'cleanup' in CleanupHook.

### DIFF
--- a/docs/source/custom_hooks.rst
+++ b/docs/source/custom_hooks.rst
@@ -380,14 +380,14 @@ variable to be the name of the current Seagrass event that is executing (or
 
     >>> CURRENT_EVENT: t.Optional[str] = None
 
-    >>> class BadCurrentEventHook(ProtoHook[t.Optional[str]]):
-    ...      def prehook(self, event_name, args, kwargs) -> t.Optional[str]:
+    >>> class BadCurrentEventHook(ProtoHook):
+    ...      def prehook(self, event_name, args, kwargs):
     ...          global CURRENT_EVENT
     ...          old_event = CURRENT_EVENT
     ...          CURRENT_EVENT = event_name
     ...          return old_event
     ...
-    ...      def posthook(self, event_name, result, context: t.Optional[str]):
+    ...      def posthook(self, event_name, result, context):
     ...          global CURRENT_EVENT
     ...          old_event = context
     ...          CURRENT_EVENT = old_event
@@ -447,14 +447,14 @@ executed.
 
    >>> from seagrass.base import ProtoHook, CleanupHook
 
-   >>> class CurrentEventHook(ProtoHook[t.Optional[str]]):
-   ...      def prehook(self, event_name, args, kwargs) -> t.Optional[str]:
+   >>> class CurrentEventHook(ProtoHook):
+   ...      def prehook(self, event_name, args, kwargs):
    ...          global CURRENT_EVENT
    ...          old_event = CURRENT_EVENT
    ...          CURRENT_EVENT = event_name
    ...          return old_event
    ...
-   ...      def cleanup(self, event_name, context: t.Optional[str]):
+   ...      def cleanup(self, event_name, context, exc):
    ...          global CURRENT_EVENT
    ...          old_event = context
    ...          CURRENT_EVENT = old_event

--- a/seagrass/base.py
+++ b/seagrass/base.py
@@ -133,6 +133,8 @@ class CleanupHook(ProtoHook[C], t.Protocol[C]):
     this interface, in case an exception is thrown during the course of the event.
     """
 
-    def cleanup(self, event_name: str, context: C):
+    def cleanup(self, event_name: str, context: C, exception: t.Optional[Exception]):
         """Perform the hook's cleanup stage. The ``event_name`` and ``context`` are the same as
-        those used by the ``posthook`` function."""
+        those used by the ``posthook`` function. If an exception was thrown while executing the
+        event it will be provided in the ``exception`` argument, otherwise, ``exception`` will
+        be ``None``."""

--- a/seagrass/events.py
+++ b/seagrass/events.py
@@ -131,10 +131,10 @@ class Event:
         if self.raise_runtime_events:
             sys.audit(self.prehook_audit_event_name, args, kwargs)
 
-        # We use the exception_raised flag to tell us whether or not an exception was raised
-        # in the course of executing the event and the hooks. If an exception *was* raised,
-        # then we only call hooks' cleanup stages, and ignore the posthooks.
-        exception_raised = False
+        # We use exception_raised to tell us whether or not an exception was raised in thej
+        # course of executing the event and the hooks. If an exception *was* raised, then
+        # we only call hooks' cleanup stages, and ignore the posthooks.
+        exception_raised = None
 
         try:
             prehook_contexts = {}
@@ -147,7 +147,7 @@ class Event:
             result = self.func(*args, **kwargs)
 
         except Exception as ex:
-            exception_raised = True
+            exception_raised = ex
             raise ex
 
         finally:
@@ -161,14 +161,14 @@ class Event:
                 context = prehook_contexts.get(hook_num, MISSING_CONTEXT)
                 if context != MISSING_CONTEXT:
                     hook = self.hooks[hook_num]
-                    if not exception_raised:
+                    if exception_raised is None:
                         try:
                             hook.posthook(self.name, result, context)
                         except Exception as ex:
                             posthook_exceptions.append(ex)
                     if isinstance(hook, CleanupHook):
                         try:
-                            hook.cleanup(self.name, context)
+                            hook.cleanup(self.name, context, exception_raised)
                         except Exception as ex:
                             posthook_exceptions.append(ex)
 

--- a/seagrass/hooks/profiler_hook.py
+++ b/seagrass/hooks/profiler_hook.py
@@ -65,7 +65,7 @@ class ProfilerHook(ProtoHook[bool]):
         self.profile.enable()
         return was_active
 
-    def cleanup(self, event_name: str, context: bool) -> None:
+    def cleanup(self, event_name: str, context: bool, exc: t.Optional[Exception]) -> None:
         # Stop profiling
         self.is_active = context
         if not self.is_active:

--- a/seagrass/hooks/runtime_audit_hook.py
+++ b/seagrass/hooks/runtime_audit_hook.py
@@ -147,7 +147,7 @@ class RuntimeAuditHook(ProtoHook[t.Optional[str]], metaclass=ABCMeta):
         pass
 
     @__update
-    def cleanup(self, event: str, context: t.Optional[str]) -> None:
+    def cleanup(self, event: str, context: t.Optional[str], exc: t.Optional[Exception]) -> None:
         self.__current_event = context
 
 


### PR DESCRIPTION
Add one additional argument to CleanupHook interface's cleanup function,
which captures the exception that was raised during the execution of the
event. If no exceptions were raised, this argument is None.

Closes #52.