### PR TITLE
Allow audit hooks set by RuntimeAuditHook to be traced.

### DIFF
--- a/seagrass/hooks/file_open_hook.py
+++ b/seagrass/hooks/file_open_hook.py
@@ -22,8 +22,8 @@ class FileOpenHook(RuntimeAuditHook):
 
     file_open_counter: t.DefaultDict[str, t.Counter[FileOpenInfo]]
 
-    def __init__(self, traceable: bool = False) -> None:
-        super().__init__(traceable=traceable)
+    def __init__(self, **kwargs) -> None:
+        super().__init__(**kwargs)
         self.file_open_counter = defaultdict(t.Counter[FileOpenInfo])
 
     def sys_hook(self, runtime_event: str, args: t.Tuple[t.Any, ...]) -> None:

--- a/seagrass/hooks/file_open_hook.py
+++ b/seagrass/hooks/file_open_hook.py
@@ -22,8 +22,8 @@ class FileOpenHook(RuntimeAuditHook):
 
     file_open_counter: t.DefaultDict[str, t.Counter[FileOpenInfo]]
 
-    def __init__(self) -> None:
-        super().__init__()
+    def __init__(self, traceable: bool = False) -> None:
+        super().__init__(traceable=traceable)
         self.file_open_counter = defaultdict(t.Counter[FileOpenInfo])
 
     def sys_hook(self, runtime_event: str, args: t.Tuple[t.Any, ...]) -> None:

--- a/test/hooks/test_file_open_hook.py
+++ b/test/hooks/test_file_open_hook.py
@@ -13,7 +13,7 @@ class FileOpenHookTestCase(HookTestCaseMixin, unittest.TestCase):
 
     @staticmethod
     def hook_gen():
-        return FileOpenHook()
+        return FileOpenHook(traceable=True)
 
     def test_hook_function(self):
         @self.auditor.audit("test.say_hello", hooks=[self.hook])

--- a/test/hooks/test_runtime_audit_hook.py
+++ b/test/hooks/test_runtime_audit_hook.py
@@ -18,7 +18,7 @@ class FileOpenRuntimeHookTestCase(RuntimeHookTestCaseMixin, unittest.TestCase):
 
     class _Hook(RuntimeAuditHook):
         def __init__(self):
-            super().__init__()
+            super().__init__(traceable=True)
             self.total_file_opens = 0
 
         def sys_hook(self, event_name, args):
@@ -86,7 +86,8 @@ class ErroneousRuntimeHookTestCase(RuntimeHookTestCaseMixin, unittest.TestCase):
     their sys_hook function."""
 
     class _Hook(RuntimeAuditHook):
-        propagate_errors: bool = False
+        def __init__(self):
+            super().__init__(propagate_errors=False, traceable=True)
 
         def sys_hook(self, event, args):
             raise ValueError("my_test_message")


### PR DESCRIPTION
Per the documentation for sys.addaudithook, audit hooks cannot be traced
by sys.settrace unless they have a __cantrace__ attribute that is set to
True. This commit adds a new keyword argument to the RuntimeAuditHook
constructor that allows users to determine whether or not they want the
hook to be traceable.