### PR TITLE
Add the TracingHook abstract base class

### DIFF
--- a/seagrass/__init__.py
+++ b/seagrass/__init__.py
@@ -126,6 +126,7 @@ class create_global_auditor(t.ContextManager[Auditor]):
 
 
 __all__ = [
+    "DEFAULT_LOGGER_NAME",
     "Auditor",
     "get_audit_logger",
     "global_auditor",

--- a/seagrass/__init__.py
+++ b/seagrass/__init__.py
@@ -1,6 +1,7 @@
 # flake8: noqa: F401
 import typing as t
 from .auditor import Auditor, get_audit_logger, DEFAULT_LOGGER_NAME
+from . import base, errors, events, hooks
 from contextvars import ContextVar
 
 # "Global auditor" that can be used to audit events without having to create an
@@ -126,6 +127,10 @@ class create_global_auditor(t.ContextManager[Auditor]):
 
 
 __all__ = [
+    "base",
+    "errors",
+    "events",
+    "hooks",
     "DEFAULT_LOGGER_NAME",
     "Auditor",
     "get_audit_logger",

--- a/seagrass/auditor.py
+++ b/seagrass/auditor.py
@@ -8,7 +8,7 @@ from seagrass.errors import EventNotFoundError
 from seagrass.events import Event
 
 # The name of the default logger used by Seagrass
-DEFAULT_LOGGER_NAME: str = "seagrass"
+DEFAULT_LOGGER_NAME: t.Final[str] = "seagrass"
 
 # A context variable that keeps track of the auditor's logger for the
 # current auditing context.

--- a/seagrass/hooks/__init__.py
+++ b/seagrass/hooks/__init__.py
@@ -6,6 +6,7 @@ from .profiler_hook import ProfilerHook
 from .runtime_audit_hook import RuntimeAuditHook
 from .stack_trace_hook import StackTraceHook
 from .timer_hook import TimerHook
+from .tracing_hook import TracingHook
 
 __all__ = [
     "CounterHook",
@@ -15,4 +16,5 @@ __all__ = [
     "StackTraceHook",
     "RuntimeAuditHook",
     "TimerHook",
+    "TracingHook",
 ]

--- a/seagrass/hooks/tracing_hook.py
+++ b/seagrass/hooks/tracing_hook.py
@@ -74,8 +74,8 @@ class TracingHook(CleanupHook[t.Optional[str]], metaclass=ABCMeta):
 
     __current_event: t.Optional[str] = None
     __is_active: bool = False
-    __is_current_hook_token: t.Optional[Token[bool]] = None
-    __old_hook_token: t.Optional[Token["TracingHook"]] = None
+    __is_current_hook_token: t.Optional[Token] = None
+    __old_hook_token: t.Optional[Token] = None
 
     @property
     def is_active(self) -> bool:

--- a/seagrass/hooks/tracing_hook.py
+++ b/seagrass/hooks/tracing_hook.py
@@ -1,0 +1,168 @@
+import sys
+import typing as t
+from abc import ABCMeta, abstractmethod
+from contextvars import ContextVar, Token
+from seagrass.base import CleanupHook
+from types import FrameType
+
+# Global variables that keep track of whether or not a TracingHook already exists.
+_tracing_hook_exists: ContextVar[bool] = ContextVar(
+    "_tracing_hook_exists", default=False
+)
+_tracing_hook: ContextVar["TracingHook"] = ContextVar("_tracing_hook")
+
+
+class TracingHook(CleanupHook[t.Optional[str]], metaclass=ABCMeta):
+    """Abstract base class for hooks that should be set as tracing functions.
+
+    **Example:** the code snippet below defines a new hook from
+    :py:class:`~seagrass.hooks.TracingHook` that checks each frame to see if ``MY_VAR`` is defined
+    locally, and if it is, it records ``MY_VAR``'s value.
+
+    .. testsetup:: tracing-hook-example
+
+        from seagrass._docs import configure_logging
+        configure_logging()
+
+    .. doctest:: tracing-hook-example
+
+        >>> import seagrass
+
+        >>> from seagrass.hooks import TracingHook
+
+        >>> class MyVarHook(TracingHook):
+        ...     def tracefunc(self, frame, event, arg):
+        ...         if "MY_VAR" in frame.f_locals:
+        ...             MY_VAR = frame.f_locals["MY_VAR"]
+        ...             if (logger := seagrass.get_audit_logger()) is not None:
+        ...                 logger.info(f"Found {MY_VAR=!r}")
+        ...         return self.tracefunc
+
+        >>> hook = MyVarHook()
+
+        >>> @seagrass.audit(seagrass.auto, hooks=[hook])
+        ... def example():
+        ...     MY_VAR = 100
+        ...     MY_VAR = "hello, world!"
+
+        >>> with hook:
+        ...     with seagrass.start_auditing():
+        ...         example()
+        (INFO) seagrass: Found MY_VAR=100
+        (INFO) seagrass: Found MY_VAR='hello, world!'
+    """
+
+    class TraceFunc(t.Protocol):
+        """A tracing function set by ``sys.settrace`` or ``threading.settrace``. The arguments to this
+        function are the same as those to the function accepted by ``sys.settrace``."""
+
+        def __call__(
+            self, frame: FrameType, event: str, arg: t.Any
+        ) -> t.Optional["TracingHook.TraceFunc"]:
+            ...
+
+    @abstractmethod
+    def tracefunc(
+        self, frame: FrameType, event: str, arg: t.Any
+    ) -> t.Optional[TraceFunc]:
+        ...
+
+    # High prehook/posthook priority since we generally don't want to trace other
+    # Seagrass hooks
+    prehook_priority: int = 15
+    posthook_priority: int = 15
+
+    __current_event: t.Optional[str] = None
+    __is_active: bool = False
+    __is_current_hook_token: t.Optional[Token[bool]] = None
+    __old_hook_token: t.Optional[Token["TracingHook"]] = None
+
+    @property
+    def is_active(self) -> bool:
+        """Return whether or not the hook is currently active (i.e., whether a Seagrass event that
+        uses the hook is currently executing.)"""
+        return self.__is_active
+
+    @property
+    def current_event(self) -> t.Optional[str]:
+        """Return the current Seagrass event that is being executed."""
+        return self.__current_event
+
+    @property
+    def is_current_tracing_hook(self) -> bool:
+        """Returns True if this hook is the current global TracingHook."""
+        if self.__is_current_hook_token is None:
+            return False
+        else:
+            return t.cast(bool, self.__is_current_hook_token.old_value)
+
+    @staticmethod
+    def get_current_tracing_hook():
+        """Get the current global tracing hook."""
+        return _tracing_hook.get()
+
+    def __enter__(self) -> "TracingHook":
+        """Make the hook the current tracing hook. Only one TracingHook can be active at a time."""
+        self.set_trace()
+        return self
+
+    def __exit__(self, *args) -> None:
+        self.remove_trace()
+
+    def __del__(self) -> None:
+        self.remove_trace()
+
+    def set_trace(self) -> None:
+        """Make this hook the current tracing hook."""
+
+        if self.__is_current_hook_token is not None:
+            return
+
+        if _tracing_hook_exists.get():
+            raise ValueError("Only one TracingHook can exist at a time")
+
+        self.__is_current_hook_token = _tracing_hook_exists.set(True)
+        self.__old_hook_token = _tracing_hook.set(self)
+        sys.settrace(self.__tracefunc)
+
+    def remove_trace(self) -> None:
+        """Stop using this hook as the current tracing hook."""
+
+        if self.__is_current_hook_token is not None:
+            _tracing_hook_exists.reset(self.__is_current_hook_token)
+
+        if self.__old_hook_token is not None:
+            _tracing_hook.reset(self.__old_hook_token)
+
+        if self.is_current_tracing_hook:
+            sys.settrace(None)
+
+        self.__is_current_hook_token = None
+        self.__old_hook_token = None
+
+    def __tracefunc(
+        self, frame: FrameType, event: str, arg: t.Any
+    ) -> t.Optional["TraceFunc"]:
+        """A wrapper around the tracefunc function. This is the function that actually gets added
+        with sys.settrace."""
+        if self.is_active:
+            return self.tracefunc(frame, event, arg)
+        else:
+            return self.__tracefunc
+
+    def prehook(
+        self, event_name: str, args: t.Tuple[t.Any, ...], kwargs: t.Dict[str, t.Any]
+    ) -> t.Optional[str]:
+        old_event = self.__current_event
+        self.__current_event = event_name
+        self.__is_active = True
+        return old_event
+
+    def cleanup(
+        self, event_name: str, context: t.Optional[str], exc: t.Optional[Exception]
+    ) -> None:
+        self.__current_event = context
+        self.__is_active = self.current_event is not None
+
+
+TracingHook.tracefunc.__doc__ = TracingHook.TraceFunc.__doc__

--- a/test/hooks/test_tracing_hook.py
+++ b/test/hooks/test_tracing_hook.py
@@ -1,0 +1,109 @@
+import typing as t
+import unittest
+from seagrass.base import CleanupHook
+from seagrass.hooks import TracingHook
+from test.utils import HookTestCaseMixin
+from types import FrameType
+
+
+class EmptyTracingHook(TracingHook):
+    """Example TracingHook where the tracing function does nothing."""
+
+    def tracefunc(
+        self, frame: FrameType, event: str, arg: t.Any
+    ) -> TracingHook.TraceFunc:
+        return self.tracefunc
+
+
+class LocalVariableExtractorHook(TracingHook):
+    """Example TracingHook that extracts the value of MY_TEST_VARIABLE from the current frame's
+    'locals' dictionary. The hook always stores the last value of MY_TEST_VARIABLE that it saw.
+    """
+
+    def __init__(self):
+        super().__init__()
+        self.reset()
+
+    def tracefunc(
+        self, frame: FrameType, event: str, arg: t.Any
+    ) -> TracingHook.TraceFunc:
+        if "MY_TEST_VARIABLE" in frame.f_locals:
+            self.last_event = self.current_event
+            self.MY_TEST_VARIABLE = frame.f_locals["MY_TEST_VARIABLE"]
+        return self.tracefunc
+
+    def reset(self):
+        self.last_event = None
+        self.MY_TEST_VARIABLE = None
+
+
+class TracingHookTestCase(HookTestCaseMixin, unittest.TestCase):
+
+    check_interfaces = (CleanupHook,)
+
+    @staticmethod
+    def hook_gen():
+        return LocalVariableExtractorHook()
+
+    def test_hook_function(self):
+        """Hook a function using a TracingHook."""
+
+        @self.auditor.audit("event.foo", hooks=[self.hook])
+        def foo(x):
+            MY_TEST_VARIABLE = x
+            self.logger.info(f"{MY_TEST_VARIABLE=}")
+
+        @self.auditor.audit("event.bar", hooks=[self.hook])
+        def bar():
+            MY_TEST_VARIABLE = 1337
+            self.logger.info(f"{MY_TEST_VARIABLE=}")
+
+        with self.hook:
+            with self.auditor.start_auditing(reset_hooks=True):
+                foo(42)
+                self.assertEqual(self.hook.MY_TEST_VARIABLE, 42)
+                self.assertEqual(self.hook.last_event, "event.foo")
+
+                bar()
+                self.assertEqual(self.hook.MY_TEST_VARIABLE, 1337)
+                self.assertEqual(self.hook.last_event, "event.bar")
+
+                # Outside of events, the is_active property should be False
+                self.assertEqual(self.hook.is_active, False)
+
+    def test_cannot_instantiate_more_than_one_tracing_hook(self):
+        """The trace functions set by multiple TracingHooks can override one another. As such,
+        error to try to make more than one TracingHook the current global TracingHook."""
+
+        empty_hook = EmptyTracingHook()
+
+        with empty_hook:
+            with self.assertRaises(ValueError):
+                with EmptyTracingHook() as _:
+                    pass
+            with self.assertRaises(ValueError):
+                with LocalVariableExtractorHook() as _:
+                    pass
+
+            # It isn't an error to create a new hook...
+            new_hook = EmptyTracingHook()
+
+            # ... but it _is_ an error to try and make it the active hook
+            with self.assertRaises(ValueError):
+                new_hook.set_trace()
+
+        # Once we've left the exterior context, it should be possible to make new hooks the
+        # current TracingHook again
+        self.hook.set_trace()
+        with self.assertRaises(ValueError):
+            empty_hook.set_trace()
+
+        # Shouldn't get any errors
+        empty_hook.remove_trace()
+        self.hook.remove_trace()
+        empty_hook.set_trace()
+        empty_hook.remove_trace()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Create a new `TracingHook` ABC that can be used to build hooks whose bodies are executed as system trace functions, via `sys.settrace`.

Additional minor changes:
- Export `DEFAULT_LOGGER_NAME` from `seagrass`.
- Explicitly import `base`, `error`, `events`, and `hooks` into `seagrass`.
- Add more precise type signatures for `Auditor.audit`.