### PR TITLE
Add compatibility with Python 3.7.

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.8, 3.9]
+        python-version: [3.7, 3.8, 3.9]
         os:
           - ubuntu-latest
         arch:

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include requirements.txt

--- a/README.md
+++ b/README.md
@@ -9,8 +9,6 @@
 Seagrass is a Python library for hooking and auditing events in your Python
 code.
 
-*Note: Seagrass is only supported for Python versions >= 3.8*
-
 ## Installation
 
 You can install the latest version of Seagrass using `pip`:

--- a/docs/source/custom_hooks.rst
+++ b/docs/source/custom_hooks.rst
@@ -21,20 +21,20 @@ Here is a basic example of a hook that just prints the arguments given to the
    class ArgsHook(ProtoHook[None]):
        
        def prehook(self, event_name, args, kwargs):
-           print(f"ArgsHook: prehook: {event_name=}, {args=}, {kwargs=}")
+           print(f"prehook: event_name={event_name!r}, args={args}, kwargs={kwargs}")
 
        def posthook(self, event_name, result, context):
-           print(f"ArgsHook: posthook: {event_name=}, {result=}, {context=}")
+           print(f"posthook: event_name={event_name!r}, result={result}, context={context}")
 
    class ElapsedTimeHook(ProtoHook[float]):
        def prehook(self, event_name, args, kwargs) -> float:
-           print(f"ElapsedTimeHook: Getting start time for {event_name}...")
+           print(f"Getting start time for {event_name}...")
            return time.time()
    
        def posthook(self, event_name, result, context: float):
            elapsed = time.time() - context
            end = time.time()
-           print(f"ElapsedTimeHook: Time spent in {event_name}: {elapsed:.1f}s")
+           print(f"Time spent in {event_name}: {elapsed:.1f}s")
 
    auditor = Auditor()
 
@@ -45,10 +45,10 @@ Here is a basic example of a hook that just prints the arguments given to the
    class ArgsHook(ProtoHook[None]):
        
        def prehook(self, event_name, args, kwargs) -> None:
-           print(f"ArgsHook: prehook: {event_name=}, {args=}, {kwargs=}")
+           print(f"prehook: event_name={event_name!r}, args={args}, kwargs={kwargs}")
 
        def posthook(self, event_name, result, context: None):
-           print(f"ArgsHook: posthook: {event_name=}, {result=}, {context=}")
+           print(f"posthook: event_name={event_name!r}, result={result}, context={context}")
 
 If you're using a typechecker like mypy, note that the type argument to
 ``ProtoHook`` is the type of the context returned by ``prehook`` (and used by
@@ -67,14 +67,14 @@ hook events:
 
    >>> @auditor.audit("example.foo", hooks=[hook])
    ... def foo(x, y, z=0):
-   ...     print(f"{x + y + z = }")
+   ...     print(f"x + y + z = {x + y + z}")
    ...     return x + y + z
 
    >>> with auditor.start_auditing():
    ...     result = foo(2, -1, z=3)
-   ArgsHook: prehook: event_name='example.foo', args=(2, -1), kwargs={'z': 3}
+   prehook: event_name='example.foo', args=(2, -1), kwargs={'z': 3}
    x + y + z = 4
-   ArgsHook: posthook: event_name='example.foo', result=4, context=None
+   posthook: event_name='example.foo', result=4, context=None
 
 ------------------------------------------------
 Passing context between the prehook and posthook
@@ -98,13 +98,13 @@ executing an event:
 
    >>> class ElapsedTimeHook(ProtoHook[float]):
    ...     def prehook(self, event_name, args, kwargs) -> float:
-   ...         print(f"ElapsedTimeHook: Getting start time for {event_name}...")
+   ...         print(f"Getting start time for {event_name}...")
    ...         return time.time()
    ...
    ...     def posthook(self, event_name, result, context: float):
    ...         elapsed = time.time() - context
    ...         end = time.time()
-   ...         print(f"ElapsedTimeHook: Time spent in {event_name}: {elapsed:.1f}s")
+   ...         print(f"Time spent in {event_name}: {elapsed:.1f}s")
    ...
 
    >>> hook = ElapsedTimeHook()
@@ -113,8 +113,8 @@ executing an event:
 
    >>> with auditor.start_auditing():
    ...     ausleep(0.1)
-   ElapsedTimeHook: Getting start time for event.sleep...
-   ElapsedTimeHook: Time spent in event.sleep: 0.1s
+   Getting start time for event.sleep...
+   Time spent in event.sleep: 0.1s
 
 ------------------------------------
 Change prehook and posthook priority
@@ -144,10 +144,10 @@ Their are two ways to change the order in which hooks are run:
 
       >>> with auditor.start_auditing():
       ...     ausleep(0.1)
-      ArgsHook: prehook: event_name='sleep_ex_1', args=(0.1,), kwargs={}
-      ElapsedTimeHook: Getting start time for sleep_ex_1...
-      ElapsedTimeHook: Time spent in sleep_ex_1: 0.1s
-      ArgsHook: posthook: event_name='sleep_ex_1', result=None, context=None
+      prehook: event_name='sleep_ex_1', args=(0.1,), kwargs={}
+      Getting start time for sleep_ex_1...
+      Time spent in sleep_ex_1: 0.1s
+      posthook: event_name='sleep_ex_1', result=None, context=None
 
    And here's the output if we put ``ElapsedTimeHook`` before ``ArgsHook``:
 
@@ -159,10 +159,10 @@ Their are two ways to change the order in which hooks are run:
 
       >>> with auditor.start_auditing():
       ...     ausleep(0.1)
-      ElapsedTimeHook: Getting start time for sleep_ex_2...
-      ArgsHook: prehook: event_name='sleep_ex_2', args=(0.1,), kwargs={}
-      ArgsHook: posthook: event_name='sleep_ex_2', result=None, context=None
-      ElapsedTimeHook: Time spent in sleep_ex_2: 0.1s
+      Getting start time for sleep_ex_2...
+      prehook: event_name='sleep_ex_2', args=(0.1,), kwargs={}
+      posthook: event_name='sleep_ex_2', result=None, context=None
+      Time spent in sleep_ex_2: 0.1s
 
 2. Set a ``prehook_priority`` and/or ``posthook_priority`` on your hooks.
    Seagrass calls :py:func:`seagrass.base.prehook_priority` and
@@ -197,10 +197,10 @@ Their are two ways to change the order in which hooks are run:
 
       >>> with auditor.start_auditing():
       ...     ausleep(0.1)
-      ArgsHook: prehook: event_name='priority_ex_1', args=(0.1,), kwargs={}
-      ElapsedTimeHook: Getting start time for priority_ex_1...
-      ElapsedTimeHook: Time spent in priority_ex_1: 0.1s
-      ArgsHook: posthook: event_name='priority_ex_1', result=None, context=None
+      prehook: event_name='priority_ex_1', args=(0.1,), kwargs={}
+      Getting start time for priority_ex_1...
+      Time spent in priority_ex_1: 0.1s
+      posthook: event_name='priority_ex_1', result=None, context=None
 
       >>> # Test with low prehook/high posthook priority
 
@@ -210,10 +210,10 @@ Their are two ways to change the order in which hooks are run:
 
       >>> with auditor.start_auditing():
       ...     ausleep(0.1)
-      ElapsedTimeHook: Getting start time for priority_ex_2...
-      ArgsHook: prehook: event_name='priority_ex_2', args=(0.1,), kwargs={}
-      ElapsedTimeHook: Time spent in priority_ex_2: 0.1s
-      ArgsHook: posthook: event_name='priority_ex_2', result=None, context=None
+      Getting start time for priority_ex_2...
+      prehook: event_name='priority_ex_2', args=(0.1,), kwargs={}
+      Time spent in priority_ex_2: 0.1s
+      posthook: event_name='priority_ex_2', result=None, context=None
 
 
 -----------------------
@@ -394,7 +394,7 @@ variable to be the name of the current Seagrass event that is executing (or
 
     >>> hook = BadCurrentEventHook()
 
-    >>> print_event = lambda: print(f"{CURRENT_EVENT=}")
+    >>> print_event = lambda: print(f"CURRENT_EVENT={CURRENT_EVENT!r}")
 
     >>> foo = auditor.audit("event.foo", print_event, hooks=[hook])
 

--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -80,10 +80,10 @@ these events is raised, along with the arguments passed to ``sys.audit``:
    >>> def foo_event_hook(event, args):
    ...     if event == "prehook:foo_event":
    ...         args, kwargs = args
-   ...         print(f"prehook called: {args=}, {kwargs=}")
+   ...         print(f"prehook called: args={args}, kwargs={kwargs}")
    ...     elif event == "posthook:foo_event":
    ...         result = args[0]
-   ...         print(f"posthook called: {result=}")
+   ...         print(f"posthook called: result={result}")
 
    >>> sys.addaudithook(foo_event_hook)
 

--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -53,11 +53,12 @@ can use Seagrass as a thin layer around ``sys.audit`` by passing
    from seagrass import Auditor
    auditor = Auditor()
 
-.. testcode:: raise-runtime-events
+.. doctest:: raise-runtime-events
+   :pyversion: >= 3.8
 
-   @auditor.audit("foo_event", raise_runtime_events=True)
-   def foo(x, y, z=0):
-       return x + y + z
+   >>> @auditor.audit("foo_event", raise_runtime_events=True)
+   ... def foo(x, y, z=0):
+   ...     return x + y + z
 
 The code snippet above created a new Seagrass event, ``"foo_event"``, that
 doesn't actually call any Seagrass hooks. Instead, whenever we call ``foo``, two
@@ -74,6 +75,7 @@ Here's an example where we add a new runtime hook that prints whenever one of
 these events is raised, along with the arguments passed to ``sys.audit``:
 
 .. doctest:: raise-runtime-events
+   :pyversion: >= 3.8
 
    >>> import sys
 

--- a/docs/source/tips_and_tricks.rst
+++ b/docs/source/tips_and_tricks.rst
@@ -187,7 +187,7 @@ function:
 
       >>> class PrintHook(ProtoHook):
       ...     def prehook(self, event, args, kwargs):
-      ...         print(f"{event=!r} raised")
+      ...         print(f"event={event!r} raised")
 
       >>> auditor = Auditor()
 

--- a/docs/source/tips_and_tricks.rst
+++ b/docs/source/tips_and_tricks.rst
@@ -57,7 +57,7 @@ with the new one:
 
    >>> with auditor.start_auditing():
    ...     p = Point2D(3, 4)
-   ...     print(f"{p.norm()=}")
+   ...     print(f"p.norm()={p.norm()}")
    PrintEventHook: event.norm triggered
    p.norm()=5.0
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+typing_extensions>=3.10.0.0; python_version < "3.8.0"

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,3 +1,4 @@
+-r requirements.txt
 black==21.5b2
 pre-commit==2.13.0
 pytest==6.2.4

--- a/seagrass/__init__.py
+++ b/seagrass/__init__.py
@@ -1,5 +1,5 @@
 # flake8: noqa: F401
-import typing as t
+import seagrass._typing as t
 from .auditor import Auditor, get_audit_logger, DEFAULT_LOGGER_NAME
 from . import base, errors, events, hooks
 from contextvars import ContextVar
@@ -143,7 +143,8 @@ __all__ += _EXPORTED_AUDITOR_ATTRIBUTES
 
 
 def __getattr__(attr: str) -> t.Any:
-    if (auditor_attr := _GLOBAL_AUDITOR_ATTRS.get(attr)) is not None:
+    auditor_attr = _GLOBAL_AUDITOR_ATTRS.get(attr)
+    if auditor_attr is not None:
         return auditor_attr.get()
     else:
         raise AttributeError(f"module {__name__!r} has no attribute {attr!r}")

--- a/seagrass/_docs.py
+++ b/seagrass/_docs.py
@@ -14,29 +14,31 @@ def configure_logging(name: str = DEFAULT_LOGGER_NAME) -> logging.Logger:
     while logger.hasHandlers():
         logger.removeHandler(logger.handlers[0])
 
-    logging.config.dictConfig({
-        "version": 1,
-        "disable_existing_loggers": False,
-        "formatters": {
-            "standard": {
-                "format": "(%(levelname)s) %(name)s: %(message)s",
+    logging.config.dictConfig(
+        {
+            "version": 1,
+            "disable_existing_loggers": False,
+            "formatters": {
+                "standard": {
+                    "format": "(%(levelname)s) %(name)s: %(message)s",
+                },
             },
-        },
-        "handlers": {
-            "default": {
-                "level": "DEBUG",
-                "formatter": "standard",
-                "class": "logging.StreamHandler",
-                "stream": "ext://sys.stdout",
+            "handlers": {
+                "default": {
+                    "level": "DEBUG",
+                    "formatter": "standard",
+                    "class": "logging.StreamHandler",
+                    "stream": "ext://sys.stdout",
+                },
             },
-        },
-        "loggers": {
-            DEFAULT_LOGGER_NAME: {
-                "handlers": ["default"],
-                "level": "DEBUG",
-                "propagate": False,
+            "loggers": {
+                DEFAULT_LOGGER_NAME: {
+                    "handlers": ["default"],
+                    "level": "DEBUG",
+                    "propagate": False,
+                },
             },
         }
-    })
+    )
 
     return logging.getLogger(DEFAULT_LOGGER_NAME)

--- a/seagrass/_typing.py
+++ b/seagrass/_typing.py
@@ -1,0 +1,38 @@
+# flake8: noqa: F401
+
+# Type annotations for Seagrass
+# Seagrass code should import type annotations from this module rather
+# than from `typing` to ensure version compatibility
+
+import sys
+import typing
+
+if sys.version_info < (3, 8):
+    import typing_extensions as t_ext
+
+    typing.Final = t_ext.Final
+    typing.Protocol = t_ext.Protocol
+    typing.runtime_checkable = t_ext.runtime_checkable
+
+from typing import (
+    Any,
+    Callable,
+    Counter,
+    ContextManager,
+    DefaultDict,
+    Dict,
+    Final,
+    Iterator,
+    List,
+    NamedTuple,
+    Optional,
+    Protocol,
+    Set,
+    Tuple,
+    Type,
+    TypeVar,
+    Union,
+    cast,
+    overload,
+    runtime_checkable,
+)

--- a/seagrass/auditor.py
+++ b/seagrass/auditor.py
@@ -1,6 +1,6 @@
 import functools
 import logging
-import typing as t
+import seagrass._typing as t
 from contextlib import contextmanager
 from contextvars import ContextVar
 from seagrass.base import LogResultsHook, ProtoHook, ResettableHook
@@ -360,7 +360,8 @@ class Auditor:
             provided name.
         """
 
-        if (wrapper := self.event_wrappers.get(event_name)) is not None:
+        wrapper = self.event_wrappers.get(event_name)
+        if wrapper is not None:
             return wrapper(*args, **kwargs)
         else:
             raise EventNotFoundError(event_name)
@@ -373,7 +374,8 @@ class Auditor:
         :raises seagrass.errors.EventNotFoundError: if the auditor can't find the event with the
             provided name.
         """
-        if (event := self.events.get(event_name)) is not None:
+        event = self.events.get(event_name)
+        if event is not None:
             event.add_hooks(*hooks)
         else:
             raise EventNotFoundError(event_name)

--- a/seagrass/base.py
+++ b/seagrass/base.py
@@ -1,5 +1,5 @@
 import logging
-import typing as t
+import seagrass._typing as t
 
 # Type variable for contexts returned by prehooks
 C = t.TypeVar("C")

--- a/seagrass/errors.py
+++ b/seagrass/errors.py
@@ -1,7 +1,7 @@
 # Basic errors that can be thrown while using Seagrass
 
 import os
-import typing as t
+import seagrass._typing as t
 
 
 class SeagrassError(Exception):

--- a/seagrass/events.py
+++ b/seagrass/events.py
@@ -64,6 +64,10 @@ class Event:
             the event is triggered.
         :param bool raise_runtime_events: if ``True``, two `Python runtime audit events`_ are raised
             using `sys.audit`_ before and after running the function wrapped by the event.
+
+            .. note::
+                This parameter is only supported for Python version >= 3.8.
+
         :param Optional[str] prehook_audit_event_name: the name of the runtime audit event
             that should be raised *before* calling the wrapped function. If set to ``None``,
             the audit event is automatically named ``f"prehook:{name}"``. This parameter is

--- a/seagrass/events.py
+++ b/seagrass/events.py
@@ -1,5 +1,5 @@
 import sys
-import typing as t
+import seagrass._typing as t
 from seagrass.base import ProtoHook, CleanupHook
 from seagrass.errors import PosthookError
 
@@ -79,8 +79,17 @@ class Event:
         self.func: F = func
         self.enabled = enabled
         self.name = name
-        self.raise_runtime_events = raise_runtime_events
         self.hooks = []
+
+        if raise_runtime_events:
+            # Check that the Python version supports audit hooks
+            if not hasattr(sys, "audit"):
+                raise NotImplementedError(
+                    "Runtime audit events are not supported for Python versions that don't "
+                    "include sys.audit and sys.addaudithook"
+                )
+
+        self.raise_runtime_events = raise_runtime_events
 
         if prehook_audit_event_name is None:
             prehook_audit_event_name = f"prehook:{name}"

--- a/seagrass/hooks/counter_hook.py
+++ b/seagrass/hooks/counter_hook.py
@@ -1,5 +1,5 @@
 import logging
-import typing as t
+import seagrass._typing as t
 from collections import Counter
 from seagrass.base import ProtoHook
 

--- a/seagrass/hooks/file_open_hook.py
+++ b/seagrass/hooks/file_open_hook.py
@@ -1,4 +1,4 @@
-import typing as t
+import seagrass._typing as t
 from collections import defaultdict
 from logging import Logger
 from .runtime_audit_hook import RuntimeAuditHook

--- a/seagrass/hooks/logging_hook.py
+++ b/seagrass/hooks/logging_hook.py
@@ -1,5 +1,5 @@
 import logging
-import typing as t
+import seagrass._typing as t
 from seagrass import get_audit_logger
 from seagrass.base import ProtoHook
 
@@ -42,7 +42,8 @@ class LoggingHook(ProtoHook[None]):
         if self.prehook_msg is None:
             pass
         else:
-            if (logger := get_audit_logger()) is not None:
+            logger = get_audit_logger()
+            if logger is not None:
                 logger.log(self.loglevel, self.prehook_msg(event_name, args, kwargs))
 
     def posthook(
@@ -54,5 +55,6 @@ class LoggingHook(ProtoHook[None]):
         if self.posthook_msg is None:
             pass
         else:
-            if (logger := get_audit_logger()) is not None:
+            logger = get_audit_logger()
+            if logger is not None:
                 logger.log(self.loglevel, self.posthook_msg(event_name, result))

--- a/seagrass/hooks/profiler_hook.py
+++ b/seagrass/hooks/profiler_hook.py
@@ -1,6 +1,6 @@
 import logging
 import pstats
-import typing as t
+import seagrass._typing as t
 from io import StringIO
 from cProfile import Profile
 from seagrass.base import ProtoHook
@@ -65,7 +65,9 @@ class ProfilerHook(ProtoHook[bool]):
         self.profile.enable()
         return was_active
 
-    def cleanup(self, event_name: str, context: bool, exc: t.Optional[Exception]) -> None:
+    def cleanup(
+        self, event_name: str, context: bool, exc: t.Optional[Exception]
+    ) -> None:
         # Stop profiling
         self.is_active = context
         if not self.is_active:
@@ -96,7 +98,8 @@ class ProfilerHook(ProtoHook[bool]):
 
         # Dump results to an in-memory stream
         output = StringIO()
-        if (stats := self.get_stats(stream=output)) is None:
+        stats = self.get_stats(stream=output)
+        if stats is None:
             logger.info("   (no samples were collected)")
             return
 

--- a/seagrass/hooks/runtime_audit_hook.py
+++ b/seagrass/hooks/runtime_audit_hook.py
@@ -26,6 +26,7 @@ class RuntimeAuditHook(ProtoHook[t.Optional[str]], metaclass=ABCMeta):
         auditor = Auditor()
 
     .. doctest:: runtime-audit-hook-example
+        :pyversion: >= 3.8
 
         >>> import sys
 

--- a/seagrass/hooks/runtime_audit_hook.py
+++ b/seagrass/hooks/runtime_audit_hook.py
@@ -1,5 +1,5 @@
 import sys
-import typing as t
+import seagrass._typing as t
 from abc import ABCMeta, abstractmethod
 from contextlib import contextmanager
 from functools import wraps
@@ -13,6 +13,9 @@ R = t.TypeVar("R")
 class RuntimeAuditHook(ProtoHook[t.Optional[str]], metaclass=ABCMeta):
     """Abstract base class that serves as a template for hooks whose body should be run as Python
     runtime audit hooks, in accordance with `PEP 578`_.
+
+    .. note::
+        :py:class:`~seagrass.hooks.RuntimeAuditHook` is only supported for Python versions >= 3.8
 
     **Examples:** in the code below, ``RuntimeEventCounterHook`` is a class derived from the
     ``RuntimeAuditHook`` base class that prints every time a runtime audit event is triggered.
@@ -33,7 +36,7 @@ class RuntimeAuditHook(ProtoHook[t.Optional[str]], metaclass=ABCMeta):
         ...         super().__init__()
         ...
         ...     def sys_hook(self, event, args):
-        ...         print(f"Encountered {event=!r} with {args=}")
+        ...         print(f"Encountered event={event!r} with args={args}")
         ...
 
         >>> hook = RuntimeEventCounterHook()
@@ -97,6 +100,12 @@ class RuntimeAuditHook(ProtoHook[t.Optional[str]], metaclass=ABCMeta):
     def __init__(
         self, propagate_errors: t.Optional[bool] = None, traceable: bool = False
     ) -> None:
+        if not hasattr(sys, "audit"):
+            raise NotImplementedError(
+                "RuntimeAuditHook is not supported for Python versions that don't "
+                "include sys.audit and sys.addaudithook"
+            )
+
         if propagate_errors is not None:
             self.propagate_errors = propagate_errors
         self.__update_properties()
@@ -125,7 +134,8 @@ class RuntimeAuditHook(ProtoHook[t.Optional[str]], metaclass=ABCMeta):
                     if self.propagate_errors:
                         raise ex
                     else:
-                        if (logger := get_audit_logger()) is not None:
+                        logger = get_audit_logger()
+                        if logger is not None:
                             # Temporarily disable the hook, since emitting a log could create new
                             # runtime events. In some cases this could lead to an infinite recursion.
                             with self.__disable_runtime_hook():

--- a/seagrass/hooks/stack_trace_hook.py
+++ b/seagrass/hooks/stack_trace_hook.py
@@ -1,5 +1,5 @@
 import inspect
-import typing as t
+import seagrass._typing as t
 from collections import Counter, defaultdict
 from seagrass.base import ProtoHook
 

--- a/seagrass/hooks/timer_hook.py
+++ b/seagrass/hooks/timer_hook.py
@@ -2,7 +2,7 @@
 
 import logging
 import time
-import typing as t
+import seagrass._typing as t
 from collections import defaultdict
 from seagrass.base import ProtoHook
 

--- a/seagrass/hooks/tracing_hook.py
+++ b/seagrass/hooks/tracing_hook.py
@@ -1,5 +1,5 @@
 import sys
-import typing as t
+import seagrass._typing as t
 from abc import ABCMeta, abstractmethod
 from contextvars import ContextVar, Token
 from seagrass.base import CleanupHook
@@ -38,7 +38,8 @@ class TracingHook(CleanupHook[TracingHookContext], metaclass=ABCMeta):
         ...     def tracefunc(self, frame, event, arg):
         ...         if "MY_VAR" in frame.f_locals:
         ...             MY_VAR = frame.f_locals["MY_VAR"]
-        ...             if (logger := seagrass.get_audit_logger()) is not None:
+        ...             logger = seagrass.get_audit_logger()
+        ...             if logger is not None:
         ...                 logger.info(f"Found {MY_VAR=!r}")
         ...         return self.tracefunc
 

--- a/seagrass/hooks/tracing_hook.py
+++ b/seagrass/hooks/tracing_hook.py
@@ -40,7 +40,7 @@ class TracingHook(CleanupHook[TracingHookContext], metaclass=ABCMeta):
         ...             MY_VAR = frame.f_locals["MY_VAR"]
         ...             logger = seagrass.get_audit_logger()
         ...             if logger is not None:
-        ...                 logger.info(f"Found {MY_VAR=!r}")
+        ...                 logger.info(f"Found MY_VAR={MY_VAR!r}")
         ...         return self.tracefunc
 
         >>> hook = MyVarHook()

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open("requirements.txt", "r", encoding="utf-8") as f:
 
 setup(
     name="seagrass",
-    version="0.6.0",
+    version="0.6.1",
     description="Auditing and profiling multi-tool",
     long_description=long_description,
     long_description_content_type="text/markdown",

--- a/setup.py
+++ b/setup.py
@@ -5,6 +5,9 @@ from setuptools import setup, find_packages
 with open("README.md", "r", encoding="utf-8") as f:
     long_description = f.read()
 
+with open("requirements.txt", "r", encoding="utf-8") as f:
+    install_requires = f.readlines()
+
 setup(
     name="seagrass",
     version="0.6.0",
@@ -26,7 +29,7 @@ setup(
     ],
     url="https://github.com/kernelmethod/Seagrass/",
     packages=find_packages(exclude=["tests"]),
-    install_requires=[],
-    python_requires=">=3.8.0",
+    install_requires=install_requires,
+    python_requires=">=3.7.0",
     license="BSD",
 )

--- a/test/hooks/test_file_open_hook.py
+++ b/test/hooks/test_file_open_hook.py
@@ -2,7 +2,7 @@
 
 import tempfile
 import unittest
-from test.utils import HookTestCaseMixin
+from test.utils import HookTestCaseMixin, req_python_version
 from seagrass.base import LogResultsHook, ResettableHook, CleanupHook
 from seagrass.hooks import FileOpenHook
 
@@ -10,6 +10,12 @@ from seagrass.hooks import FileOpenHook
 class FileOpenHookTestCase(HookTestCaseMixin, unittest.TestCase):
 
     check_interfaces = (LogResultsHook, ResettableHook, CleanupHook)
+
+    # These test cases require the use of sys.audit and sys.addaudithook, so they're disabled
+    # for Python versions < 3.8
+    @req_python_version(min=(3, 8))
+    def setUp(self):
+        super().setUp()
 
     @staticmethod
     def hook_gen():

--- a/test/hooks/test_logger_hook.py
+++ b/test/hooks/test_logger_hook.py
@@ -13,11 +13,11 @@ class LoggingHookTestCase(HookTestCaseMixin, unittest.TestCase):
         super(HookTestCaseMixin, self).setUp()
 
         self.hook_pre = LoggingHook(
-            prehook_msg=lambda e, args, kwargs: f"hook_pre: {e}, {args=}, {kwargs=}",
+            prehook_msg=lambda e, args, kwargs: f"hook_pre: {e}, args={args}, kwargs={kwargs}",
         )
         self.hook_both = LoggingHook(
-            prehook_msg=lambda e, args, kwargs: f"hook_both: {e}, {args=}, {kwargs=}",
-            posthook_msg=lambda e, result: f"hook_both: {e}, {result=}",
+            prehook_msg=lambda e, args, kwargs: f"hook_both: {e}, args={args}, kwargs={kwargs}",
+            posthook_msg=lambda e, result: f"hook_both: {e}, result={result}",
             loglevel=logging.INFO,
         )
 
@@ -44,13 +44,17 @@ class LoggingHookTestCase(HookTestCaseMixin, unittest.TestCase):
             multiply_or_add(*args, **kwargs_add)
 
         output = self.logging_output.getvalue().rstrip().split("\n")
-        self.assertEqual(output[0], f"(DEBUG) hook_pre: {event}, {args=}, kwargs={{}}")
-        self.assertEqual(output[1], f"(INFO) hook_both: {event}, {args=}, kwargs={{}}")
-        self.assertEqual(output[2], f"(INFO) hook_both: {event}, result={24}")
         self.assertEqual(
-            output[3], f"(DEBUG) hook_pre: {event}, {args=}, kwargs={kwargs_add}"
+            output[0], f"(DEBUG) hook_pre: {event}, args={args}, kwargs={{}}"
         )
         self.assertEqual(
-            output[4], f"(INFO) hook_both: {event}, {args=}, kwargs={kwargs_add}"
+            output[1], f"(INFO) hook_both: {event}, args={args}, kwargs={{}}"
+        )
+        self.assertEqual(output[2], f"(INFO) hook_both: {event}, result={24}")
+        self.assertEqual(
+            output[3], f"(DEBUG) hook_pre: {event}, args={args}, kwargs={kwargs_add}"
+        )
+        self.assertEqual(
+            output[4], f"(INFO) hook_both: {event}, args={args}, kwargs={kwargs_add}"
         )
         self.assertEqual(output[5], f"(INFO) hook_both: {event}, result={10}")

--- a/test/hooks/test_tracing_hook.py
+++ b/test/hooks/test_tracing_hook.py
@@ -1,5 +1,5 @@
 import seagrass
-import typing as t
+import seagrass._typing as t
 import unittest
 from seagrass.base import ProtoHook, CleanupHook
 from seagrass.hooks import TracingHook
@@ -52,12 +52,12 @@ class TracingHookTestCase(HookTestCaseMixin, unittest.TestCase):
         @self.auditor.audit("event.foo", hooks=[self.hook])
         def foo(x):
             MY_TEST_VARIABLE = x
-            self.logger.info(f"{MY_TEST_VARIABLE=}")
+            self.logger.info(f"MY_TEST_VARIABLE={MY_TEST_VARIABLE}")
 
         @self.auditor.audit("event.bar", hooks=[self.hook])
         def bar():
             MY_TEST_VARIABLE = 1337
-            self.logger.info(f"{MY_TEST_VARIABLE=}")
+            self.logger.info(f"MY_TEST_VARIABLE={MY_TEST_VARIABLE}")
 
         with self.auditor.start_auditing(reset_hooks=True):
             foo(42)
@@ -101,7 +101,7 @@ class TracingHookTestCase(HookTestCaseMixin, unittest.TestCase):
         def bar(x):
             MY_TEST_VARIABLE = x + 1
             MY_TEST_VARIABLE = foo(MY_TEST_VARIABLE) - 5
-            self.logger.info(f"{MY_TEST_VARIABLE=}")
+            self.logger.info(f"MY_TEST_VARIABLE={MY_TEST_VARIABLE}")
             self.assertTrue(trace_hook.is_active)
 
         with self.auditor.start_auditing(reset_hooks=True):

--- a/test/test_base.py
+++ b/test/test_base.py
@@ -1,7 +1,7 @@
 # Tests for protocols and functions defined in seagrass.base
 
 import seagrass.base as base
-import typing as t
+import seagrass._typing as t
 import unittest
 
 

--- a/test/utils.py
+++ b/test/utils.py
@@ -3,7 +3,7 @@
 import logging
 import logging.config
 import sys
-import typing as t
+import seagrass._typing as t
 from functools import wraps
 from io import StringIO
 from seagrass import Auditor
@@ -124,10 +124,10 @@ def req_python_version(
         err_msg = f"{err_msg} {min[0]}.{min[1]} <= version <= {max[0]}.{max[1]}"
         bad_version = True
     elif (min is not None and max is None) and (version < min):
-        err_msg = f"{err_msg} {min[0]}.{min[1]} <= version"
+        err_msg = f"{err_msg} version >= {min[0]}.{min[1]}"
         bad_version = True
-    elif (min is None and max is not None) and (version > max):
-        err_msg = f"{err_msg} version <= {max[0]}.{max[1]}"
+    elif (min is None and max is not None) and (version >= max):
+        err_msg = f"{err_msg} version < {max[0]}.{max[1]}"
         bad_version = True
 
     if not bad_version:

--- a/tox.ini
+++ b/tox.ini
@@ -75,6 +75,6 @@ omit =
 
 [gh-actions]
 python =
-    3.7: py37
+    3.7: py37, doctests
     3.8: py38, pre-commit, doctests
     3.9: py39, doctests

--- a/tox.ini
+++ b/tox.ini
@@ -2,33 +2,28 @@
 minversion = 3.23.0
 skip_missing_interpreters = true
 envlist =
-    py37,
-    py38,
-    py39,
+    py{37,38,39}-{unittests,doctests}
     pre-commit,
     docs,
-    doctests,
 isolated_build = true
 
 [testenv]
-description = Run unit tests with {basepython}
+description =
+    unittests: Run unit tests with {basepython}
+    doctests: Run doctests with {basepython}
 deps =
-    -rrequirements.txt
-    -rrequirements_dev.txt
+    unittests: -rrequirements_dev.txt
+    doctests: -rdocs/requirements_docs.txt
 commands =
-    pytest --cov-report term-missing --cov=seagrass test/
+    unittests: pytest --cov-report term-missing --cov=seagrass test/
+    doctests: sphinx-build -b doctest -d "{toxworkdir}/.doctree" ./docs/source/ "{toxworkdir}/doctests/" -W
 
 [testenv:pre-commit]
 description = Run pre-commit hooks
+deps = -rrequirements_dev.txt
 commands =
     pre-commit install
     pre-commit run --all-files
-
-[testenv:doctests]
-description = Run doctests with {basepython}
-deps = -rdocs/requirements_docs.txt
-commands =
-    sphinx-build -b doctest -d "{toxworkdir}/.doctree" ./docs/source/ "{toxworkdir}/doctests/" -W
 
 [testenv:docs]
 description = Build documentation with Sphinx
@@ -75,6 +70,6 @@ omit =
 
 [gh-actions]
 python =
-    3.7: py37, doctests
-    3.8: py38, pre-commit, doctests
-    3.9: py39, doctests
+    3.7: py37-{unittests,doctests}
+    3.8: py38-{unittests,doctests}, pre-commit
+    3.9: py39-{unittests,doctests}, doctests

--- a/tox.ini
+++ b/tox.ini
@@ -2,6 +2,7 @@
 minversion = 3.23.0
 skip_missing_interpreters = true
 envlist =
+    py37,
     py38,
     py39,
     pre-commit,
@@ -11,7 +12,9 @@ isolated_build = true
 
 [testenv]
 description = Run unit tests with {basepython}
-deps = -rrequirements_dev.txt
+deps =
+    -rrequirements.txt
+    -rrequirements_dev.txt
 commands =
     pytest --cov-report term-missing --cov=seagrass test/
 
@@ -38,6 +41,7 @@ commands =
 description = Generate a development environment
 usedevelop = true
 deps =
+    -rrequirements.txt
     -rrequirements_dev.txt
     -rdocs/requirements_docs.txt
 
@@ -71,5 +75,6 @@ omit =
 
 [gh-actions]
 python =
+    3.7: py37
     3.8: py38, pre-commit, doctests
     3.9: py39, doctests


### PR DESCRIPTION
Make various adjustments so that Seagrass is compatible with Python 3.7.
We make two changes to provide type annotations that are supported in
Python >= 3.8 but not for earlier versions:

- Use typing_extensions to import various type annotations that Seagrass
  uses that were unavailable in Python 3.7. Note that the
  typing_extensions dependency is only installed for Python < 3.8; for
  later versions it is skipped over in the requirements.txt.
- Instead of importing type annotation classes from `typing`, they're
  now imported from the new seagrass._typing. This allows us to
  dynamically import annotations via typing_extensions for Python 3.7.

In addition, I've stopped using the following features which were also
unavailable before Python 3.8:

- Stop using the walrus operator (:=) to make assignments.
- Stop using f-strings patterned like f"{var=}" as shorthand for
  f"var={var}".

Finally, in cases where we have to use sys.audit or sys.addaudithook,
Seagrass will raise a NotImplementedError if sys.audit is unavailable.
The test suite skips the test cases that explicitly depend on the
existence of runtime audit hooking for Python < 3.8, and there are new
tests to ensure that NotImplementError will be raised for these
versions.