### PR TITLE
Add ContextManagerHook for converting runtime contexts into hooks

### DIFF
--- a/seagrass/__init__.py
+++ b/seagrass/__init__.py
@@ -1,6 +1,7 @@
 # flake8: noqa: F401
 import seagrass._typing as t
 from .auditor import Auditor, get_audit_logger, DEFAULT_LOGGER_NAME
+from .events import get_current_event
 from . import base, errors, events, hooks
 from contextvars import ContextVar
 
@@ -134,6 +135,7 @@ __all__ = [
     "DEFAULT_LOGGER_NAME",
     "Auditor",
     "get_audit_logger",
+    "get_current_event",
     "global_auditor",
     "create_global_auditor",
     "auto",

--- a/seagrass/_typing.py
+++ b/seagrass/_typing.py
@@ -36,3 +36,20 @@ from typing import (
     overload,
     runtime_checkable,
 )
+
+# Unique type used throughout Seagrass to represent a missing value
+
+class Missing:
+    __slots__: typing.List[str] = []
+    def __repr__(self):
+        return f"<seagrass._typing.{self.__class__.__name__}"
+
+MISSING: typing.Final[Missing] = Missing()
+
+T = typing.TypeVar("T")
+
+# Maybe[T] is a type that represents a value that is potentially missing its value.
+# This is distinct from Optional[T], which represents a value that could have type
+# T or that could be None. In cases where a None value should be allowed, this type
+# may be used instead.
+Maybe = typing.Union[T,Missing]

--- a/seagrass/base.py
+++ b/seagrass/base.py
@@ -138,9 +138,19 @@ class CleanupHook(ProtoHook[C], t.Protocol[C]):
         self,
         event_name: str,
         context: C,
-        exc: t.Tuple[t.Optional[Exception], t.Optional[str], t.Optional[TracebackType]],
-    ) -> None:
+        exc: t.Tuple[
+            t.Optional[t.Type[BaseException]],
+            t.Optional[BaseException],
+            t.Optional[TracebackType],
+        ],
+    ) -> t.Optional[bool]:
         """Perform the hook's cleanup stage. The ``event_name`` and ``context`` are the same as
         those used by the ``posthook`` function. If an exception was thrown while executing the
         event it will be provided in the ``exception`` argument, otherwise, ``exception`` will
-        be ``None``."""
+        be ``None``.
+
+        If ``cleanup`` returns a boolean value, that value is used to decide whether to suppress
+        any exceptions that were raised during event execution.
+
+        :rtype: Optional[bool]
+        """

--- a/seagrass/base.py
+++ b/seagrass/base.py
@@ -1,5 +1,6 @@
 import logging
 import seagrass._typing as t
+from types import TracebackType
 
 # Type variable for contexts returned by prehooks
 C = t.TypeVar("C")
@@ -133,7 +134,12 @@ class CleanupHook(ProtoHook[C], t.Protocol[C]):
     this interface, in case an exception is thrown during the course of the event.
     """
 
-    def cleanup(self, event_name: str, context: C, exception: t.Optional[Exception]):
+    def cleanup(
+        self,
+        event_name: str,
+        context: C,
+        exc: t.Tuple[t.Optional[Exception], t.Optional[str], t.Optional[TracebackType]],
+    ) -> None:
         """Perform the hook's cleanup stage. The ``event_name`` and ``context`` are the same as
         those used by the ``posthook`` function. If an exception was thrown while executing the
         event it will be provided in the ``exception`` argument, otherwise, ``exception`` will

--- a/seagrass/events.py
+++ b/seagrass/events.py
@@ -1,7 +1,6 @@
 import sys
 import seagrass._typing as t
 from contextvars import ContextVar
-from functools import cached_property
 from seagrass.base import ProtoHook, CleanupHook
 from seagrass.errors import PosthookError
 from types import TracebackType
@@ -42,10 +41,13 @@ class _HookErrorCapture:
     by a Seagrass event."""
 
     exc: t.Tuple[t.Optional[Exception], t.Optional[str], t.Optional[TracebackType]]
+    __exception_raised: t.Optional[bool] = None
 
-    @cached_property
+    @property
     def exception_raised(self):
-        return self.exc != (None, None, None)
+        if self.__exception_raised is None:
+            self.__exception_raised = self.exc != (None, None, None)
+        return self.__exception_raised
 
     def __enter__(self):
         return self

--- a/seagrass/hooks/__init__.py
+++ b/seagrass/hooks/__init__.py
@@ -1,4 +1,5 @@
 # flake8: noqa: F401
+from .context_manager_hook import ContextManagerHook
 from .counter_hook import CounterHook
 from .file_open_hook import FileOpenHook
 from .logging_hook import LoggingHook

--- a/seagrass/hooks/context_manager_hook.py
+++ b/seagrass/hooks/context_manager_hook.py
@@ -1,0 +1,103 @@
+import seagrass._typing as t
+from seagrass.base import ProtoHook
+from types import TracebackType
+
+C = t.TypeVar("C")
+CtxType = t.Optional[t.ContextManager[C]]
+
+
+class ContextManagerHook(ProtoHook[CtxType[C]]):
+    """A hook that wraps around a context manager, calling the context manager's ``__enter__`` and
+    ``__exit__`` methods whenever the hook is activated."""
+
+    __current_cm: t.Optional[t.ContextManager[C]] = None
+
+    @property
+    def current_context_manager(self) -> t.Optional[t.ContextManager[C]]:
+        """Return the current context manager instance being used by the hook."""
+        return self.__current_cm
+
+    @property
+    def is_active(self) -> bool:
+        """Returns ``True`` if an event that uses this hook is currently being executed."""
+        return self.current_context_manager is not None
+
+    def __init__(
+        self,
+        cm: t.Union[t.ContextManager[C], t.Callable[[], t.ContextManager[C]]],
+        nest: bool = False,
+    ) -> None:
+        """Create a new :py:class:`ContextManagerHook`.
+
+        :param t.Union[t.ContextManager, t.Callable[[], t.ContextManager]] cm: a context manager
+            (i.e., an object with ``__enter__`` and ``__exit__`` methods) or a function that takes
+            no arguments and creates a new context manager.
+        :param bool nest: whether successive invocations of the context manager should be nested.
+            If ``nest=False`` and another Seagrass event that uses this hook gets called, the
+            prehook and cleanup stages of the hook will be skipped. In general, you should set
+            ``nest=True`` if your context manager should be used along the lines of
+
+                .. code::
+
+                    with cm:
+                        # Execute outer event
+                        ...
+                        with cm:
+                            # Execute inner event
+                            ...
+                        # Continue executing outer event
+                        ...
+
+            and ``nest=False`` if your context manager should be used as
+
+                .. code::
+
+                    with cm:
+                        # Execute outer event
+                        ...
+                        # Execute inner event
+                        ...
+                        # Continue executing outer event
+                        ...
+        """
+        self.cm = cm
+        self.nest = nest
+
+    def __create_cm(self) -> t.ContextManager[C]:
+        if isinstance(self.cm, t.ContextManager):
+            return self.cm
+        else:
+            return self.cm()
+
+    def prehook(
+        self, event: str, args: t.Tuple[t.Any, ...], kwargs: t.Dict[str, t.Any]
+    ) -> CtxType[C]:
+        if self.nest or self.current_context_manager is None:
+            cm = self.__create_cm()
+            cm.__enter__()
+        else:
+            cm = self.current_context_manager
+
+        old_cm = self.current_context_manager
+        self.__current_cm = cm
+        return old_cm
+
+    def cleanup(
+        self,
+        event: str,
+        context: CtxType[C],
+        exc: t.Tuple[
+            t.Optional[t.Type[BaseException]],
+            t.Optional[BaseException],
+            t.Optional[TracebackType],
+        ],
+    ) -> t.Optional[bool]:
+        old_cm = context
+        current_cm = self.current_context_manager
+        self.__current_cm = old_cm
+
+        if (self.nest or not self.is_active) and current_cm is not None:
+            exc_type, exc_val, tb = exc
+            return current_cm.__exit__(exc_type, exc_val, tb)
+        else:
+            return None

--- a/seagrass/hooks/logging_hook.py
+++ b/seagrass/hooks/logging_hook.py
@@ -42,7 +42,7 @@ class LoggingHook(ProtoHook[None]):
         if self.prehook_msg is None:
             pass
         else:
-            logger = get_audit_logger()
+            logger = get_audit_logger(None)
             if logger is not None:
                 logger.log(self.loglevel, self.prehook_msg(event_name, args, kwargs))
 
@@ -55,6 +55,6 @@ class LoggingHook(ProtoHook[None]):
         if self.posthook_msg is None:
             pass
         else:
-            logger = get_audit_logger()
+            logger = get_audit_logger(None)
             if logger is not None:
                 logger.log(self.loglevel, self.posthook_msg(event_name, result))

--- a/seagrass/hooks/runtime_audit_hook.py
+++ b/seagrass/hooks/runtime_audit_hook.py
@@ -135,7 +135,7 @@ class RuntimeAuditHook(ProtoHook[t.Optional[str]], metaclass=ABCMeta):
                     if self.propagate_errors:
                         raise ex
                     else:
-                        logger = get_audit_logger()
+                        logger = get_audit_logger(None)
                         if logger is not None:
                             # Temporarily disable the hook, since emitting a log could create new
                             # runtime events. In some cases this could lead to an infinite recursion.

--- a/seagrass/hooks/tracing_hook.py
+++ b/seagrass/hooks/tracing_hook.py
@@ -132,7 +132,7 @@ class TracingHook(CleanupHook[TracingHookContext], metaclass=ABCMeta):
         return old_event, exists_token, tracefunc_token
 
     def cleanup(
-        self, event_name: str, context: TracingHookContext, exc: t.Optional[Exception]
+        self, event_name: str, context: TracingHookContext, exc: t.Tuple[t.Any, ...],
     ) -> None:
         old_event, exists_token, tracefunc_token = context
 

--- a/seagrass/hooks/tracing_hook.py
+++ b/seagrass/hooks/tracing_hook.py
@@ -38,7 +38,7 @@ class TracingHook(CleanupHook[TracingHookContext], metaclass=ABCMeta):
         ...     def tracefunc(self, frame, event, arg):
         ...         if "MY_VAR" in frame.f_locals:
         ...             MY_VAR = frame.f_locals["MY_VAR"]
-        ...             logger = seagrass.get_audit_logger()
+        ...             logger = seagrass.get_audit_logger(None)
         ...             if logger is not None:
         ...                 logger.info(f"Found MY_VAR={MY_VAR!r}")
         ...         return self.tracefunc

--- a/test/base/test_cleanup_hook.py
+++ b/test/base/test_cleanup_hook.py
@@ -106,7 +106,7 @@ class CleanupHookTestCase(SeagrassTestCaseMixin, unittest.TestCase):
 
             self.assertEqual(self.hook_a.counter, 1)
             self.assertEqual(self.hook_b.counter, 2)
-            self.assertEqual(self.hook_b.exception, self.ex)
+            self.assertEqual(self.hook_b.exception[0], RuntimeError)
 
     def test_hooks_b_and_c(self):
         # Tests for _HookC + _HookB
@@ -120,8 +120,8 @@ class CleanupHookTestCase(SeagrassTestCaseMixin, unittest.TestCase):
             # hook_c.cleanup are called.
             self.assertEqual(self.hook_b.counter, 1)
             self.assertEqual(self.hook_c.counter, 1)
-            self.assertEqual(self.hook_b.exception, None)
-            self.assertEqual(self.hook_c.exception, None)
+            self.assertEqual(self.hook_b.exception, (None, None, None))
+            self.assertEqual(self.hook_c.exception, (None, None, None))
 
             # Despite the fact that an error is raised in the posthook, we should prioritize
             # the error that was raised by the wrapped function.
@@ -132,8 +132,8 @@ class CleanupHookTestCase(SeagrassTestCaseMixin, unittest.TestCase):
                 self.ex = ex
             self.assertEqual(self.hook_b.counter, 2)
             self.assertEqual(self.hook_c.counter, 2)
-            self.assertEqual(self.hook_b.exception, self.ex)
-            self.assertEqual(self.hook_c.exception, self.ex)
+            self.assertEqual(self.hook_b.exception[0], RuntimeError)
+            self.assertEqual(self.hook_c.exception[0], RuntimeError)
 
     def test_hooks_b_and_d(self):
         # Tests for _HookD + _HookB, and _HookB + _HookD
@@ -170,7 +170,7 @@ class CleanupHookTestCase(SeagrassTestCaseMixin, unittest.TestCase):
                 self.ex = ex
             self.assertEqual(self.hook_b.counter, 1)
             self.assertEqual(self.hook_d.counter, 0)
-            self.assertEqual(self.hook_b.exception, self.ex)
+            self.assertEqual(self.hook_b.exception[0], AssertionError)
             self.assertEqual(self.hook_d.exception, None)
 
             try:
@@ -180,5 +180,5 @@ class CleanupHookTestCase(SeagrassTestCaseMixin, unittest.TestCase):
                 self.ex = ex
             self.assertEqual(self.hook_b.counter, 2)
             self.assertEqual(self.hook_d.counter, 0)
-            self.assertEqual(self.hook_b.exception, self.ex)
+            self.assertEqual(self.hook_b.exception[0], AssertionError)
             self.assertEqual(self.hook_d.exception, None)

--- a/test/hooks/test_context_manager_hook.py
+++ b/test/hooks/test_context_manager_hook.py
@@ -1,0 +1,99 @@
+import unittest
+from collections import Counter
+from seagrass import get_current_event, get_audit_logger
+from seagrass.base import CleanupHook
+from seagrass.hooks import ContextManagerHook
+from test.utils import HookTestCaseMixin
+
+
+class CounterContextManager:
+    def __init__(self):
+        self.ctr = Counter()
+        self.exc_ctr = Counter()
+
+    def __enter__(self):
+        self.ctr[get_current_event()] += 1
+
+    def __exit__(self, exc_type, exc_val, traceback):
+        if exc_type is not None:
+            self.exc_ctr[get_current_event()] += 1
+
+
+class LoggerContextManager:
+    def __enter__(self):
+        get_audit_logger().debug(f"Calling {get_current_event()}")
+
+    def __exit__(self, exc_type, exc_val, traceback):
+        get_audit_logger().debug(f"Exiting {get_current_event()}")
+
+
+class ContextManagerHookTestCase(HookTestCaseMixin, unittest.TestCase):
+
+    check_interfaces = (CleanupHook,)
+
+    def setUp(self):
+        super().setUp()
+        self.cm = CounterContextManager()
+        self.hook = ContextManagerHook(self.cm, nest=True)
+
+    def test_hook_function(self):
+        @self.auditor.audit("test.foo", hooks=[self.hook])
+        def foo():
+            pass
+
+        @self.auditor.audit("test.bar", hooks=[self.hook])
+        def bar():
+            assert False
+
+        with self.auditor.start_auditing():
+            foo()
+            with self.assertRaises(AssertionError):
+                bar()
+
+        self.assertEqual(self.cm.ctr["test.foo"], 1)
+        self.assertEqual(self.cm.ctr["test.bar"], 1)
+        self.assertEqual(self.cm.exc_ctr["test.foo"], 0)
+        self.assertEqual(self.cm.exc_ctr["test.bar"], 1)
+
+
+class CallableContextManagerHookTestCase(HookTestCaseMixin, unittest.TestCase):
+    """Tests for ContextManagerHook in the case where the input context manager is a callable
+    function."""
+
+    check_interfaces = (CleanupHook,)
+
+    @staticmethod
+    def hook_gen():
+        return ContextManagerHook(LoggerContextManager, nest=False)
+
+    def test_hook_function(self):
+        @self.auditor.audit("test.foo", hooks=[self.hook])
+        def foo():
+            pass
+
+        @self.auditor.audit("test.bar", hooks=[self.hook])
+        def bar():
+            foo()
+
+        with self.auditor.start_auditing():
+            bar()
+
+        output = self.logging_output.getvalue().rstrip().split("\n")
+        self.assertEqual(output[0], "(DEBUG) Calling test.bar")
+        self.assertEqual(output[1], "(DEBUG) Exiting test.bar")
+
+        self.hook.nest = True
+
+        with self.auditor.start_auditing():
+            bar()
+
+        output = self.logging_output.getvalue().rstrip().split("\n")
+        output = output[2:]
+        self.assertEqual(output[0], "(DEBUG) Calling test.bar")
+        self.assertEqual(output[1], "(DEBUG) Calling test.foo")
+        self.assertEqual(output[2], "(DEBUG) Exiting test.foo")
+        self.assertEqual(output[3], "(DEBUG) Exiting test.bar")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/test_auditor.py
+++ b/test/test_auditor.py
@@ -148,8 +148,11 @@ class SimpleAuditorFunctionsTestCase(SeagrassTestCaseMixin, unittest.TestCase):
         inner_auditor = Auditor(logger="inner")
         self.assertNotEqual(outer_auditor.logger, inner_auditor.logger)
 
-        # Outside of an auditing context, get_audit_logger should return None
-        self.assertEqual(get_audit_logger(), None)
+        # Outside of an auditing context, get_audit_logger should return the default value
+        # (or otherwise raise a LookupError)
+        self.assertEqual(get_audit_logger(None), None)
+        with self.assertRaises(LookupError):
+            get_audit_logger()
 
         # Within an auditing context, get_audit_logger() should return the logger
         # for the most recent auditing context.
@@ -162,8 +165,10 @@ class SimpleAuditorFunctionsTestCase(SeagrassTestCaseMixin, unittest.TestCase):
             self.assertEqual(get_audit_logger(), outer_auditor.logger)
 
         # Now that we're back outside of an auditing context, get_audit_logger()
-        # should once again return None.
-        self.assertEqual(get_audit_logger(), None)
+        # should once again raise an error/return the default
+        self.assertEqual(get_audit_logger(None), None)
+        with self.assertRaises(LookupError):
+            get_audit_logger()
 
     def test_filter_events(self):
         hook = seagrass.hooks.CounterHook()


### PR DESCRIPTION
Add a new class `ContextManagerHook` that can convert a context manager (an object with `__enter__` and `__exit__` methods) and converts it into a Seagrass hook.

Some additional changes:
- The `cleanup` method of the `CleanupHook` interface now accepts a tuple containing the inputs to `__exit__` in its third argument.
- Add a `get_current_event` method to get a string with the current event name.
- Modify `get_audit_logger` to accept a default value, and return an error if no default value is provided and we aren't executing in an auditing context. `get_current_event` has the same behavior.