### PR TITLE
Add async support

### DIFF
--- a/seagrass/auditor.py
+++ b/seagrass/auditor.py
@@ -222,6 +222,8 @@ class Auditor:
             unique. This parameter can either be a string, or it can be a function that takes the
             audited function and creates a string from it, e.g.
             ``event_name = lambda func: f"event.{func.__name__}"``.
+        :param bool use_async: wrap the function in an asynchronous event. This should be set to
+            ``True`` if ``func`` is ``async``.
         :param Optional[Callable] func: the function that should be wrapped in a new event.
         :param Optional[List[ProtoHook]] hooks: a list of hooks to call whenever the new event is
             triggered.
@@ -316,7 +318,10 @@ class Auditor:
     def async_audit(
         self, *args, **kwargs
     ) -> t.Union[AuditDecorator[F], AuditedFunc[F]]:
-        result = self.audit(*args, **kwargs)
+        """Call :py:meth:`audit` with `use_async=True`. See the documentation for :py:meth:`audit`
+        for more information.
+        """
+        result = self.audit(*args, use_async=True, **kwargs)
         return t.cast(t.Union[AuditDecorator[F], AuditedFunc[F]], result)
 
     def create_event(self, event_name: str, **kwargs) -> t.Callable[..., None]:

--- a/seagrass/auditor.py
+++ b/seagrass/auditor.py
@@ -5,7 +5,7 @@ from contextlib import contextmanager
 from contextvars import ContextVar
 from seagrass.base import LogResultsHook, ProtoHook, ResettableHook
 from seagrass.errors import EventNotFoundError
-from seagrass.events import Event
+from seagrass.events import Event, AsyncEvent, SyncEvent
 
 # The name of the default logger used by Seagrass
 DEFAULT_LOGGER_NAME: t.Final[str] = "seagrass"
@@ -203,7 +203,6 @@ class Auditor:
         self,
         event_name: t.Union[str, t.Callable[[F], str]],
         func: F,
-        hooks: t.Optional[t.List[ProtoHook]] = None,
         **kwargs,
     ) -> AuditedFunc[F]:
         ...  # pragma: no cover
@@ -213,6 +212,7 @@ class Auditor:
         event_name: t.Union[str, t.Callable[[F], str]],
         func: t.Optional[F] = None,
         hooks: t.Optional[t.List[ProtoHook]] = None,
+        use_async: bool = False,
         **kwargs,
     ) -> t.Union[AuditDecorator[F], AuditedFunc[F]]:
         """Wrap a function with a new auditing event. You can call ``audit`` either as a function
@@ -269,7 +269,9 @@ class Auditor:
         if func is None:
 
             def decorator(func: F) -> AuditedFunc[F]:
-                return self.audit(event_name, func, hooks=hooks, **kwargs)
+                return self.audit(
+                    event_name, func, hooks=hooks, use_async=use_async, **kwargs
+                )
 
             return decorator
 
@@ -287,7 +289,13 @@ class Auditor:
         for hook in hooks:
             self.hooks.add(hook)
 
-        new_event = Event(func, event_name, hooks=hooks, **kwargs)
+        if use_async:
+            new_event: t.Union[AsyncEvent, SyncEvent] = AsyncEvent(
+                func, event_name, hooks=hooks, **kwargs
+            )
+        else:
+            new_event = SyncEvent(func, event_name, hooks=hooks, **kwargs)
+
         self.events[event_name] = new_event
 
         @functools.wraps(func)
@@ -304,6 +312,12 @@ class Auditor:
 
         self.event_wrappers[event_name] = wrapper
         return wrapper
+
+    def async_audit(
+        self, *args, **kwargs
+    ) -> t.Union[AuditDecorator[F], AuditedFunc[F]]:
+        result = self.audit(*args, **kwargs)
+        return t.cast(t.Union[AuditDecorator[F], AuditedFunc[F]], result)
 
     def create_event(self, event_name: str, **kwargs) -> t.Callable[..., None]:
         """Create a new "empty" event. When this event is executed, it runs any hooks that are

--- a/seagrass/auditor.py
+++ b/seagrass/auditor.py
@@ -194,6 +194,8 @@ class Auditor:
         self,
         event_name: t.Union[str, t.Callable[[F], str]],
         func: None,
+        hooks: t.Optional[t.List[ProtoHook]] = None,
+        use_async: bool = False,
         **kwargs,
     ) -> AuditDecorator[F]:
         ...  # pragma: no cover
@@ -203,6 +205,8 @@ class Auditor:
         self,
         event_name: t.Union[str, t.Callable[[F], str]],
         func: F,
+        hooks: t.Optional[t.List[ProtoHook]] = None,
+        use_async: bool = False,
         **kwargs,
     ) -> AuditedFunc[F]:
         ...  # pragma: no cover
@@ -316,13 +320,16 @@ class Auditor:
         return wrapper
 
     def async_audit(
-        self, *args, **kwargs
+        self,
+        event_name: t.Union[str, t.Callable[[F], str]],
+        func: t.Optional[F] = None,
+        hooks: t.Optional[t.List[ProtoHook]] = None,
+        **kwargs,
     ) -> t.Union[AuditDecorator[F], AuditedFunc[F]]:
         """Call :py:meth:`audit` with `use_async=True`. See the documentation for :py:meth:`audit`
         for more information.
         """
-        result = self.audit(*args, use_async=True, **kwargs)
-        return t.cast(t.Union[AuditDecorator[F], AuditedFunc[F]], result)
+        return self.audit(event_name, func, use_async=True, hooks=hooks, **kwargs)
 
     def create_event(self, event_name: str, **kwargs) -> t.Callable[..., None]:
         """Create a new "empty" event. When this event is executed, it runs any hooks that are

--- a/seagrass/events/__init__.py
+++ b/seagrass/events/__init__.py
@@ -1,8 +1,10 @@
 # flake8: noqa: F401
 
-from .event import Event, get_current_event
+from .contexts import get_current_event
+from .event import Event, AsyncEvent, SyncEvent
 
 __all__ = [
-    "Event",
+    "AsyncEvent",
+    "SyncEvent",
     "get_current_event",
 ]

--- a/seagrass/events/contexts.py
+++ b/seagrass/events/contexts.py
@@ -1,9 +1,34 @@
 import seagrass._typing as t
+from contextvars import ContextVar
 from dataclasses import dataclass
 from seagrass.base import ProtoHook, CleanupHook
 from types import TracebackType
 
 T = t.TypeVar("T")
+
+# Context variable used to store the current event
+current_event: ContextVar[str] = ContextVar("seagrass_current_event")
+
+
+@t.overload
+def get_current_event(default: t.Missing) -> str:
+    ...  # pragma: no cover
+
+
+@t.overload
+def get_current_event(default: T) -> t.Union[str, T]:
+    ...  # pragma: no cover
+
+
+def get_current_event(default: t.Maybe[T] = t.MISSING) -> t.Union[str, T]:
+    """Get the current Seagrass event that is being executed.
+
+    :raises LookupError: if no Seagrass event is currently under execution.
+    """
+    if isinstance(default, t.Missing):
+        return current_event.get()
+    else:
+        return current_event.get(default)
 
 
 @dataclass
@@ -46,3 +71,14 @@ class HookExecutionContext(t.Generic[T]):
             if isinstance(self.hook, CleanupHook):
                 exc = (exc_type, exc_val, tb)
                 self.hook.cleanup(self.data.event_name, self.prehook_context, exc)
+
+    async def __aenter__(self) -> "HookExecutionContext":
+        return self.__enter__()
+
+    async def __aexit__(
+        self,
+        exc_type: t.Optional[t.Type[BaseException]],
+        exc_val: t.Optional[BaseException],
+        tb: t.Optional[TracebackType],
+    ) -> None:
+        return self.__exit__(exc_type, exc_val, tb)

--- a/seagrass/events/contexts.py
+++ b/seagrass/events/contexts.py
@@ -11,7 +11,7 @@ current_event: ContextVar[str] = ContextVar("seagrass_current_event")
 
 
 @t.overload
-def get_current_event(default: t.Missing) -> str:
+def get_current_event() -> str:
     ...  # pragma: no cover
 
 

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open("requirements.txt", "r", encoding="utf-8") as f:
 
 setup(
     name="seagrass",
-    version="0.8.0",
+    version="0.8.1",
     description="Auditing and profiling multi-tool",
     long_description=long_description,
     long_description_content_type="text/markdown",

--- a/test/test_async.py
+++ b/test/test_async.py
@@ -1,5 +1,6 @@
 # Tests for creating events out of async functions
 
+import asyncio
 import unittest
 from seagrass import get_current_event
 from seagrass.hooks import CounterHook, LoggingHook
@@ -14,10 +15,12 @@ class AsyncEventTestCase(SeagrassTestCaseMixin, unittest.TestCase):
             prehook_msg=lambda event, *args: f"Starting {event}",
             posthook_msg=lambda event, *args: f"Leaving {event}",
         )
-        self.hooks = [self.ctr_hook]
+        self.hooks = [self.ctr_hook, self.log_hook]
 
     @async_test
     async def test_create_event_over_async_function(self):
+        """Ensure that auditing works correctly when we call an async event."""
+
         @self.auditor.audit("test.foo", use_async=True, hooks=self.hooks)
         async def foo():
             self.assertEqual(get_current_event(), "test.foo")
@@ -26,6 +29,63 @@ class AsyncEventTestCase(SeagrassTestCaseMixin, unittest.TestCase):
             await foo()
 
         self.assertEqual(self.ctr_hook.event_counter["test.foo"], 1)
+
+        output = self.logging_output.getvalue().rstrip().split("\n")
+        self.assertEqual(output[0], "(DEBUG) Starting test.foo")
+        self.assertEqual(output[1], "(DEBUG) Leaving test.foo")
+
+    @async_test
+    async def test_wrap_nested_async_events(self):
+        """Ensure that auditing works correctly when we call an async event inside another
+        async event."""
+
+        @self.auditor.async_audit("test.foo", hooks=self.hooks)
+        async def foo():
+            self.assertEqual(get_current_event(), "test.foo")
+
+        @self.auditor.async_audit("test.bar", hooks=self.hooks)
+        async def bar(recurse: bool):
+            self.assertEqual(get_current_event(), "test.bar")
+            await foo()
+            self.assertEqual(get_current_event(), "test.bar")
+
+            if recurse:
+                await asyncio.gather(bar(False), foo(), bar(False))
+
+            self.assertEqual(get_current_event(), "test.bar")
+
+        with self.auditor.start_auditing():
+            await bar(True)
+
+        self.assertEqual(self.ctr_hook.event_counter["test.foo"], 4)
+        self.assertEqual(self.ctr_hook.event_counter["test.bar"], 3)
+
+    @async_test
+    async def test_wrapped_async_and_sync_events(self):
+        """Check that auditing works correctly if we run a sync event inside an async event."""
+
+        @self.auditor.audit("test.foo", hooks=self.hooks)
+        def foo():
+            self.assertEqual(get_current_event(), "test.foo")
+
+        @self.auditor.async_audit("test.bar", hooks=self.hooks)
+        async def bar(recurse: bool):
+            self.assertEqual(get_current_event(), "test.bar")
+            foo()
+            self.assertEqual(get_current_event(), "test.bar")
+
+            if recurse:
+                await bar(False)
+                foo()
+                await bar(False)
+
+            self.assertEqual(get_current_event(), "test.bar")
+
+        with self.auditor.start_auditing():
+            await bar(True)
+
+        self.assertEqual(self.ctr_hook.event_counter["test.foo"], 4)
+        self.assertEqual(self.ctr_hook.event_counter["test.bar"], 3)
 
 
 if __name__ == "__main__":

--- a/test/test_async.py
+++ b/test/test_async.py
@@ -1,0 +1,32 @@
+# Tests for creating events out of async functions
+
+import unittest
+from seagrass import get_current_event
+from seagrass.hooks import CounterHook, LoggingHook
+from test.utils import SeagrassTestCaseMixin, async_test
+
+
+class AsyncEventTestCase(SeagrassTestCaseMixin, unittest.TestCase):
+    def setUp(self):
+        super().setUp()
+        self.ctr_hook = CounterHook()
+        self.log_hook = LoggingHook(
+            prehook_msg=lambda event, *args: f"Starting {event}",
+            posthook_msg=lambda event, *args: f"Leaving {event}",
+        )
+        self.hooks = [self.ctr_hook]
+
+    @async_test
+    async def test_create_event_over_async_function(self):
+        @self.auditor.audit("test.foo", use_async=True, hooks=self.hooks)
+        async def foo():
+            self.assertEqual(get_current_event(), "test.foo")
+
+        with self.auditor.start_auditing():
+            await foo()
+
+        self.assertEqual(self.ctr_hook.event_counter["test.foo"], 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/test_auditor.py
+++ b/test/test_auditor.py
@@ -32,17 +32,6 @@ class CreateAuditorTestCase(unittest.TestCase):
     def setUp(self):
         self.logging_output = StringIO()
 
-    def test_default_logger_used_by_auditor(self):
-        # By default, Auditor should use the "seagrass" logger if no logger is specified
-        self._configure_logger(logging.getLogger("seagrass"))
-
-        auditor = Auditor()
-        auditor.logger.info("Hello, world!")
-        auditor.logger.debug("This message shouldn't appear")
-
-        output = self.logging_output.getvalue()
-        self.assertEqual(output, "(INFO) seagrass: Hello, world!\n")
-
     def test_use_custom_logger_for_auditor(self):
         # If a logger is explicitly specified, Auditor should use that logger instead
         # of the default. The logger can either be provided as a logging.Logger

--- a/test/utils.py
+++ b/test/utils.py
@@ -1,5 +1,6 @@
 # Testing utilities and base classes for testing Seagrass
 
+import asyncio
 import logging
 import logging.config
 import sys
@@ -8,6 +9,15 @@ from functools import wraps
 from io import StringIO
 from seagrass import Auditor
 from seagrass.base import ProtoHook
+
+
+def async_test(func):
+    @wraps(func)
+    def wrapper(*args, **kwargs):
+        loop = asyncio.get_event_loop()
+        loop.run_until_complete(func(*args, **kwargs))
+
+    return wrapper
 
 
 class SeagrassTestCaseMixin:


### PR DESCRIPTION
Make it possible to audit async functions by passing `use_audit=True` into `Auditor.audit`, or by using `Auditor.async_audit`.