### PR TITLE
Change the RuntimeAuditHook and TracingHook APIs

### DIFF
--- a/seagrass/hooks/file_open_hook.py
+++ b/seagrass/hooks/file_open_hook.py
@@ -22,7 +22,7 @@ class FileOpenHook(RuntimeAuditHook):
     file_open_counter: t.DefaultDict[str, t.Counter[FileOpenInfo]]
 
     def __init__(self, **kwargs) -> None:
-        super().__init__(**kwargs)
+        super().__init__(self.sys_hook, **kwargs)
         self.file_open_counter = defaultdict(t.Counter[FileOpenInfo])
 
     def sys_hook(self, runtime_event: str, args: t.Tuple[t.Any, ...]) -> None:

--- a/seagrass/hooks/runtime_audit_hook.py
+++ b/seagrass/hooks/runtime_audit_hook.py
@@ -32,7 +32,7 @@ class RuntimeAuditHook(ProtoHook[t.Optional[str]]):
 
         >>> class RuntimeEventCounterHook(RuntimeAuditHook):
         ...     def __init__(self):
-        ...         super().__init__()
+        ...         super().__init__(self.sys_hook)
         ...
         ...     def sys_hook(self, event, args):
         ...         print(f"Encountered event={event!r} with args={args}")

--- a/seagrass/hooks/runtime_audit_hook.py
+++ b/seagrass/hooks/runtime_audit_hook.py
@@ -1,6 +1,5 @@
 import sys
 import seagrass._typing as t
-from abc import ABCMeta, abstractmethod
 from contextlib import contextmanager
 from functools import wraps
 from seagrass import get_audit_logger
@@ -10,9 +9,8 @@ from seagrass.base import ProtoHook
 R = t.TypeVar("R")
 
 
-class RuntimeAuditHook(ProtoHook[t.Optional[str]], metaclass=ABCMeta):
-    """Abstract base class that serves as a template for hooks whose body should be run as Python
-    runtime audit hooks, in accordance with `PEP 578`_.
+class RuntimeAuditHook(ProtoHook[t.Optional[str]]):
+    """A hook that executes its body as a Python runtime audit hook, in accordance with `PEP 578`_.
 
     .. note::
         :py:class:`~seagrass.hooks.RuntimeAuditHook` is only supported for Python versions >= 3.8
@@ -62,11 +60,6 @@ class RuntimeAuditHook(ProtoHook[t.Optional[str]], metaclass=ABCMeta):
     __current_event: t.Optional[str] = None
     __is_active: bool
 
-    @abstractmethod
-    def sys_hook(self, event: str, args: t.Tuple[t.Any, ...]) -> None:
-        """The runtime auditing hook that gets executed every time sys.audit() is called.
-        This must be defined in child classes of RuntimeAuditHook."""
-
     @property
     def is_active(self) -> bool:
         """Return whether or not the hook is currently active (i.e., whether a Seagrass event that
@@ -99,13 +92,18 @@ class RuntimeAuditHook(ProtoHook[t.Optional[str]], metaclass=ABCMeta):
         return wrapper
 
     def __init__(
-        self, propagate_errors: t.Optional[bool] = None, traceable: bool = False
+        self,
+        sys_hook: t.Callable[[str, t.Tuple[t.Any, ...]], None],
+        propagate_errors: t.Optional[bool] = None,
+        traceable: bool = False,
     ) -> None:
         if not hasattr(sys, "audit"):
             raise NotImplementedError(
                 "RuntimeAuditHook is not supported for Python versions that don't "
                 "include sys.audit and sys.addaudithook"
             )
+
+        self.sys_hook = sys_hook
 
         if propagate_errors is not None:
             self.propagate_errors = propagate_errors

--- a/seagrass/hooks/tracing_hook.py
+++ b/seagrass/hooks/tracing_hook.py
@@ -39,7 +39,7 @@ class TracingHook(CleanupHook[TracingHookContext]):
         ...         logger = seagrass.get_audit_logger(None)
         ...         if logger is not None:
         ...             logger.info(f"Found MY_VAR={MY_VAR!r}")
-        ...     return self.tracefunc
+        ...     return tracefunc
 
         >>> hook = TracingHook(tracefunc)
 

--- a/seagrass/hooks/tracing_hook.py
+++ b/seagrass/hooks/tracing_hook.py
@@ -1,6 +1,5 @@
 import sys
 import seagrass._typing as t
-from abc import ABCMeta, abstractmethod
 from contextvars import ContextVar, Token
 from seagrass.base import CleanupHook
 from types import FrameType
@@ -16,8 +15,8 @@ _tracing_hook: ContextVar[t.Optional["TracingHook.TraceFunc"]] = ContextVar(
 TracingHookContext = t.Tuple[t.Optional[str], Token, Token]
 
 
-class TracingHook(CleanupHook[TracingHookContext], metaclass=ABCMeta):
-    """Abstract base class for hooks that should be set as tracing functions.
+class TracingHook(CleanupHook[TracingHookContext]):
+    """Seagrass hook wrapper for tracing functions.
 
     **Example:** the code snippet below defines a new hook from
     :py:class:`~seagrass.hooks.TracingHook` that checks each frame to see if ``MY_VAR`` is defined
@@ -34,16 +33,15 @@ class TracingHook(CleanupHook[TracingHookContext], metaclass=ABCMeta):
 
         >>> from seagrass.hooks import TracingHook
 
-        >>> class MyVarHook(TracingHook):
-        ...     def tracefunc(self, frame, event, arg):
-        ...         if "MY_VAR" in frame.f_locals:
-        ...             MY_VAR = frame.f_locals["MY_VAR"]
-        ...             logger = seagrass.get_audit_logger(None)
-        ...             if logger is not None:
-        ...                 logger.info(f"Found MY_VAR={MY_VAR!r}")
-        ...         return self.tracefunc
+        >>> def tracefunc(frame, event, arg):
+        ...     if "MY_VAR" in frame.f_locals:
+        ...         MY_VAR = frame.f_locals["MY_VAR"]
+        ...         logger = seagrass.get_audit_logger(None)
+        ...         if logger is not None:
+        ...             logger.info(f"Found MY_VAR={MY_VAR!r}")
+        ...     return self.tracefunc
 
-        >>> hook = MyVarHook()
+        >>> hook = TracingHook(tracefunc)
 
         >>> @seagrass.audit(seagrass.auto, hooks=[hook])
         ... def example():
@@ -65,11 +63,15 @@ class TracingHook(CleanupHook[TracingHookContext], metaclass=ABCMeta):
         ) -> t.Optional["TracingHook.TraceFunc"]:
             ...  # pragma: no cover
 
-    @abstractmethod
-    def tracefunc(
-        self, frame: FrameType, event: str, arg: t.Any
-    ) -> t.Optional[TraceFunc]:
-        ...  # pragma: no cover
+    def __init__(self, tracefunc: TraceFunc) -> None:
+        """Create a new TracingHook.
+
+        :param TraceFunc tracefunc: the function that should be used to perform tracing via
+            `sys.settrace`_.
+
+        .. _sys.settrace: https://docs.python.org/3/library/sys.html#sys.settrace
+        """
+        self.tracefunc = tracefunc
 
     # High prehook/posthook priority since we generally don't want to trace other
     # Seagrass hooks
@@ -95,12 +97,15 @@ class TracingHook(CleanupHook[TracingHookContext], metaclass=ABCMeta):
         return _tracing_hook.get()
 
     def __create_tracefunc(
-        self, func: t.Optional["TraceFunc"],
+        self,
+        func: t.Optional["TraceFunc"],
     ) -> "TraceFunc":
         """A wrapper around the tracefunc function. This is the function that actually gets added
         with sys.settrace."""
 
-        def tracefunc(frame: FrameType, event: str, arg: t.Any) -> "TracingHook.TraceFunc":
+        def tracefunc(
+            frame: FrameType, event: str, arg: t.Any
+        ) -> "TracingHook.TraceFunc":
             if func is not None and self.is_active:
                 return self.__create_tracefunc(func(frame, event, arg))
             else:
@@ -131,7 +136,10 @@ class TracingHook(CleanupHook[TracingHookContext], metaclass=ABCMeta):
         return old_event, exists_token, tracefunc_token
 
     def cleanup(
-        self, event_name: str, context: TracingHookContext, exc: t.Tuple[t.Any, ...],
+        self,
+        event_name: str,
+        context: TracingHookContext,
+        exc: t.Tuple[t.Any, ...],
     ) -> None:
         old_event, exists_token, tracefunc_token = context
 
@@ -141,6 +149,3 @@ class TracingHook(CleanupHook[TracingHookContext], metaclass=ABCMeta):
         _tracing_hook.reset(tracefunc_token)
 
         sys.settrace(_tracing_hook.get())
-
-
-TracingHook.tracefunc.__doc__ = TracingHook.TraceFunc.__doc__

--- a/test/hooks/test_runtime_audit_hook.py
+++ b/test/hooks/test_runtime_audit_hook.py
@@ -20,7 +20,7 @@ class FileOpenTestHook(RuntimeAuditHook):
     FileOpenHook."""
 
     def __init__(self):
-        super().__init__(traceable=True)
+        super().__init__(self.sys_hook, traceable=True)
         self.total_file_opens = 0
 
     def sys_hook(self, event_name, args):
@@ -34,7 +34,7 @@ class ErroneousHook(RuntimeAuditHook):
     """A runtime audit hook that raises an error whenever sys_hook gets called."""
 
     def __init__(self):
-        super().__init__(propagate_errors=False, traceable=True)
+        super().__init__(self.sys_hook, propagate_errors=False, traceable=True)
 
     def sys_hook(self, event, args):
         raise ValueError("my_test_message")

--- a/test/hooks/test_tracing_hook.py
+++ b/test/hooks/test_tracing_hook.py
@@ -10,9 +10,12 @@ from types import FrameType
 class EmptyTracingHook(TracingHook):
     """Example TracingHook where the tracing function does nothing."""
 
+    def __init__(self) -> None:
+        return super().__init__(self.tracefunc)
+
     def tracefunc(
         self, frame: FrameType, event: str, arg: t.Any
-    ) -> TracingHook.TraceFunc:
+    ) -> t.Optional[TracingHook.TraceFunc]:
         return self.tracefunc
 
 
@@ -22,12 +25,12 @@ class LocalVariableExtractorHook(TracingHook):
     """
 
     def __init__(self):
-        super().__init__()
+        super().__init__(self.tracefunc)
         self.reset()
 
     def tracefunc(
         self, frame: FrameType, event: str, arg: t.Any
-    ) -> TracingHook.TraceFunc:
+    ) -> t.Optional[TracingHook.TraceFunc]:
         if "MY_TEST_VARIABLE" in frame.f_locals:
             self.last_event = self.current_event
             self.MY_TEST_VARIABLE = frame.f_locals["MY_TEST_VARIABLE"]


### PR DESCRIPTION
Change the RuntimeAuditHook and TracingHook APIs so that either hook can be instantiated, and it's no longer strictly necessary to subclass either hook type.