### PR TITLE
Add type annotations for the exported global auditor attributes.

### DIFF
--- a/seagrass/_typing.py
+++ b/seagrass/_typing.py
@@ -5,14 +5,15 @@
 # than from `typing` to ensure version compatibility
 
 import sys
-import typing
+import typing as t
 
 if sys.version_info < (3, 8):
     import typing_extensions as t_ext
 
-    typing.Final = t_ext.Final
-    typing.Protocol = t_ext.Protocol
-    typing.runtime_checkable = t_ext.runtime_checkable
+    t.Final = t_ext.Final
+    t.Literal = t_ext.Literal
+    t.Protocol = t_ext.Protocol
+    t.runtime_checkable = t_ext.runtime_checkable
 
 from typing import (
     Any,
@@ -25,6 +26,7 @@ from typing import (
     Generic,
     Iterator,
     List,
+    Literal,
     NamedTuple,
     Optional,
     Protocol,
@@ -40,17 +42,33 @@ from typing import (
 
 # Unique type used throughout Seagrass to represent a missing value
 
+
 class Missing:
-    __slots__: typing.List[str] = []
-    def __repr__(self):
+    __slots__: t.List[str] = []
+
+    def __repr__(self) -> str:
         return f"<seagrass._typing.{self.__class__.__name__}"
 
-MISSING: typing.Final[Missing] = Missing()
 
-T = typing.TypeVar("T")
+MISSING: t.Final[Missing] = Missing()
+
+T = t.TypeVar("T")
 
 # Maybe[T] is a type that represents a value that is potentially missing its value.
 # This is distinct from Optional[T], which represents a value that could have type
 # T or that could be None. In cases where a None value should be allowed, this type
 # may be used instead.
-Maybe = typing.Union[T,Missing]
+Maybe = t.Union[T, Missing]
+
+F = t.TypeVar("F", bound=t.Callable)
+
+
+class AuditedFunc(t.Protocol[F]):
+    __event_name__: str
+    __call__: F
+
+
+class AuditDecorator(t.Protocol[F]):
+    @property
+    def __call__(self) -> t.Callable[[F], AuditedFunc[F]]:
+        ...

--- a/test/test_auditor.py
+++ b/test/test_auditor.py
@@ -226,8 +226,6 @@ class GlobalAuditorTestCase(unittest.TestCase):
 
         with seagrass.create_global_auditor() as auditor:
             self.assertEqual(seagrass.global_auditor(), auditor)
-            self.assertEqual(seagrass.audit, auditor.audit)
-            self.assertEqual(seagrass.create_event, auditor.create_event)
 
             # Any events created inside of this context should be created with the new auditor
             @seagrass.audit("test.foo", hooks=[hook])
@@ -237,8 +235,6 @@ class GlobalAuditorTestCase(unittest.TestCase):
         # Outside of the context, the auditor should be set back to the original
         # global auditor.
         self.assertNotEqual(seagrass.global_auditor(), auditor)
-        self.assertNotEqual(seagrass.audit, auditor.audit)
-        self.assertNotEqual(seagrass.create_event, auditor.create_event)
 
         # Events created inside of the context should only be raised with the newly-created
         # auditor.
@@ -254,11 +250,8 @@ class GlobalAuditorTestCase(unittest.TestCase):
         auditor = Auditor()
         with seagrass.create_global_auditor(auditor):
             self.assertEqual(seagrass.global_auditor(), auditor)
-            self.assertEqual(seagrass.audit, auditor.audit)
-            self.assertEqual(seagrass.create_event, auditor.create_event)
 
-        self.assertNotEqual(seagrass.audit, auditor.audit)
-        self.assertNotEqual(seagrass.create_event, auditor.create_event)
+        self.assertNotEqual(seagrass.global_auditor(), auditor)
 
 
 if __name__ == "__main__":

--- a/test/test_events.py
+++ b/test/test_events.py
@@ -7,7 +7,7 @@ from seagrass import auto, get_current_event
 from seagrass.hooks import CounterHook
 from test.utils import SeagrassTestCaseMixin, req_python_version
 
-with seagrass.create_global_auditor():
+with seagrass.create_global_auditor() as _:
 
     class ExampleClass:
         # Test class used to check how functions are auto-named by Seagrass


### PR DESCRIPTION
Add annotations for the methods and properties of the global_auditor()
that get exported from seagrass/__init__.py, e.g. audit(),
create_event(), and so on. In addition, the new method for retrieving
these attributes is significantly streamlined, and no longer relies on
complex caching mechanisms plus the use of the __getattr__ function.