### PR TITLE
Fix issue where comparison with t.MISSING could raise an exception.

### DIFF
--- a/seagrass/events/contexts.py
+++ b/seagrass/events/contexts.py
@@ -63,7 +63,7 @@ class HookExecutionContext(t.Generic[T]):
         tb: t.Optional[TracebackType],
     ) -> None:
         try:
-            if self.data.result != t.MISSING:
+            if not isinstance(self.data.result, t.Missing):
                 self.hook.posthook(
                     self.data.event_name, self.data.result, self.prehook_context
                 )

--- a/seagrass/events/event.py
+++ b/seagrass/events/event.py
@@ -183,7 +183,7 @@ class SyncEvent(Event):
         with self._event_context(args, kwargs) as event_data:
             event_data.result = self.func(*args, **kwargs)
 
-        if event_data.result == t.MISSING:
+        if isinstance(event_data.result, t.Missing):
             # This point should never be reached
             raise ValueError("Event result was not recorded")  # pragma: no cover
 
@@ -196,7 +196,7 @@ class AsyncEvent(Event):
         with self._event_context(args, kwargs) as event_data:
             event_data.result = await self.func(*args, **kwargs)
 
-        if event_data.result == t.MISSING:
+        if isinstance(event_data.result, t.Missing):
             # This point should never be reached
             raise ValueError("Event result was not recorded")  # pragma: no cover
 


### PR DESCRIPTION
In limited circumstances, making a comparison `x == t.MISSING` or
`x != t.MISSING` could raise an exception, especially when the type of
`x` is completely outside the scope of Seagrass. Namely, if `x`
overrides `__eq__` or `__neq__`, it has to be able to accept arguments
of type `t.Missing` in order for this comparison to work.

I found that in practice, some classes that override these methods
expect their argument to be of the same class, which can trigger
hard-to-diagnose errors. This commit fixes the problem by changing
comparisons like `x == t.MISSING` to `isinstance(x, t.Missing)`, which
is much less likely to result in an error.

Closes #66.