### PR TITLE
Declare that the package includes type annotations.

### DIFF
--- a/seagrass/_typing.py
+++ b/seagrass/_typing.py
@@ -5,21 +5,28 @@
 # than from `typing` to ensure version compatibility
 
 from sys import version_info as _version_info
-
-# Bring all of the attributes of typing into scope
 from typing import *
 
-# Attributes that must be brought in from typing_extensions for Python < 3.8
-_extended_attrs = ("Final", "Literal", "Protocol", "runtime_checkable")
+# The __all__ list includes all of the attributes of typing that were
+# brought into scope.
+import typing as _t
+
+__all__: List[str] = []
+__all__ += _t.__all__  # type: ignore[attr-defined]
+
+# Import additional attributes for Python < 3.8
+_extended_attrs = ["Final", "Literal", "Protocol", "runtime_checkable"]
 
 if _version_info < (3, 8):
     import typing_extensions as _t_ext
-    for attr in _extended_attrs:
+
+    for attr in filter(lambda attr: attr not in __all__, _extended_attrs):
         # Dynamically bring the attribute into scope by updating the globals
         # dictionary
         globals().update({attr: getattr(_t_ext, attr)})
+        __all__.append(attr)
 
-
+# Additional types for Seagrass:
 class Missing:
     """Unique type used throughout Seagrass to represent a missing value."""
 
@@ -51,3 +58,16 @@ class AuditDecorator(Protocol[_F]):
     @property
     def __call__(self) -> Callable[[_F], AuditedFunc[_F]]:
         ...
+
+
+# Add additional types to the __all__ list:
+
+__all__ += [
+    "Missing",
+    "MISSING",
+    "Maybe",
+    "AuditedFunc",
+    "AuditDecorator",
+]
+
+__all__ = sorted(__all__)

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open("requirements.txt", "r", encoding="utf-8") as f:
 
 setup(
     name="seagrass",
-    version="0.9.0",
+    version="0.9.1",
     description="Auditing and profiling multi-tool",
     long_description=long_description,
     long_description_content_type="text/markdown",
@@ -28,6 +28,7 @@ setup(
         "Operating System :: OS Independent",
     ],
     url="https://github.com/kernelmethod/Seagrass/",
+    package_data={"seagrass": ["py.typed"]},
     packages=find_packages(exclude=["tests"]),
     install_requires=install_requires,
     python_requires=">=3.7.0",

--- a/tox.ini
+++ b/tox.ini
@@ -67,6 +67,8 @@ exclude =
 omit =
     # Code used for documentation generation
     seagrass/_docs.py
+    # Type annotations
+    seagrass/_typing.py
 
 [gh-actions]
 python =


### PR DESCRIPTION
Modify the setup.py to declare that the package includes type
annotations by adding a py.typed file and by adding the "package_data"
key to the call to setup(). This should ensure that packages that depend
on Seagrass are able to find type annotations when running mypy.

Bump version to v0.9.1.