### PR TITLE
Some fixes to typechecking

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,5 +1,6 @@
 -r requirements.txt
-black==21.5b2
+black==22.6.0
+mypy==0.961
 pre-commit==2.13.0
 pytest==6.2.4
 pytest-cov==2.12.1

--- a/seagrass/_typing.py
+++ b/seagrass/_typing.py
@@ -46,17 +46,21 @@ _T = TypeVar("_T")
 # may be used instead.
 Maybe = Union[_T, Missing]
 
+_R = TypeVar("_R")
 _F = TypeVar("_F", bound=Callable)
+_FR = TypeVar("_FR", bound=Callable[..., _R])
 
 
-class AuditedFunc(Protocol[_F]):
+class AuditedFunc(_t.Generic[_FR]):
+
     __event_name__: str
-    __call__: _F
+
+    def __call__(*args, **kwargs) -> _R:
+        ...
 
 
-class AuditDecorator(Protocol[_F]):
-    @property
-    def __call__(self) -> Callable[[_F], AuditedFunc[_F]]:
+class AuditDecorator(Protocol):
+    def __call__(self, func: _F) -> _F:
         ...
 
 

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open("requirements.txt", "r", encoding="utf-8") as f:
 
 setup(
     name="seagrass",
-    version="0.9.1",
+    version="0.9.2",
     description="Auditing and profiling multi-tool",
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
Change the definition of AuditDecorator and AuditedFunc to make it
easier to use them in conjunction with typechecking in dependent
libraries. In particular, AuditDecorator has been re-defined to return
the same type of function that it took as input. AuditedFunc has been
modified to be a subtype of Callable.