### PR TITLE
Export ContextManagerHook from seagrass.hooks

### DIFF
--- a/seagrass/hooks/__init__.py
+++ b/seagrass/hooks/__init__.py
@@ -11,6 +11,7 @@ from .timer_hook import TimerHook
 from .tracing_hook import TracingHook
 
 __all__ = [
+    "ContextManagerHook",
     "CounterHook",
     "FileOpenHook",
     "LoggingHook",


### PR DESCRIPTION
The `seagrass.hooks` submodule did not previously export `ContextManagerHook`; this PR fixes that issue.